### PR TITLE
[PLXUTILS-176] Fix SCM info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@ limitations under the License.
   <url>http://plexus.codehaus.org/plexus-utils</url>
 
   <scm>
-    <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
-    <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
+    <connection>scm:git:git@github.com:codehaus-plexus/plexus-utils.git</connection>
+    <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-utils.git</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-utils</url>
     <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
SCM info in plexus-utils 3.0.22-SNAPSHOT incorrectly points to plexus-compiler git repo.
See: http://jira.codehaus.org/browse/PLXUTILS-176