### PR TITLE
offloading file copy work to operating system allows potential speedup

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/FileUtils.java
@@ -1105,6 +1105,16 @@ public class FileUtils
     private static void doCopyFile( File source, File destination )
         throws IOException
     {
+        // offload to operating system if supported
+        if ( Java7Detector.isJava7() )
+            doCopyFileUsingNewIO( source, destination );
+        else
+            doCopyFileUsingLegacyIO( source, destination );
+    }
+
+    private static void doCopyFileUsingLegacyIO( File source, File destination )
+        throws IOException
+    {
         FileInputStream fis = null;
         FileOutputStream fos = null;
         FileChannel input = null;
@@ -1139,6 +1149,12 @@ public class FileUtils
             IOUtil.close( input );
             IOUtil.close( fis );
         }
+    }
+
+    private static void doCopyFileUsingNewIO( File source, File destination )
+        throws IOException
+    {
+        NioFiles.copy( source, destination );
     }
 
     /**


### PR DESCRIPTION
Since Plexus Utils enforces Java 7 it is safe to invoke NIO operations introduced by JRE 7. Among those operations are methods for potentially offloading work to the operating system. Theoretically this should be (much) faster on modern JREs than pumping bytes up and down the JVM just to get them from one file into another. Even without any actual performance gain it makes sense to get rid of custom code in favor of JRE code, as it improves class loading speed and reduces memory and
on-disk footprint, while cutting down number of potential bugs at the same time.