### PR TITLE
bug fix: silently fails overwriting symlinks

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/NioFiles.java
+++ b/src/main/java/org/codehaus/plexus/util/NioFiles.java
@@ -120,10 +120,11 @@ public class NioFiles
         throws IOException
     {
         Path link = symlink.toPath();
-        if ( !Files.exists( link, LinkOption.NOFOLLOW_LINKS ) )
+        if ( Files.exists( link, LinkOption.NOFOLLOW_LINKS ) )
         {
-            link = Files.createSymbolicLink( link, target.toPath() );
+            Files.delete( link );
         }
+        link = Files.createSymbolicLink( link, target.toPath() );
         return link.toFile();
     }
 


### PR DESCRIPTION
When A is an existing symlink to B, then createSymbolicLink(A,C) does neither overwrite A->B by A->C (as expected in analogy to the behavior of copy(A,C)) nor does it throw an exception nor does it return A->B to indicate the failure, but it actually "silently fails", i. e. it returns A->C!

This certainly is heavily problematic, unsymmetric to what copy(File,File) and Files.createSymbolicLink(Path,Path) do, and certainly unwanted and buggy behavior.

The solution is to delete any existing target before creating the symlic, hence copying the behavior of copy(File,File).