### PR TITLE
UT Fix : Quote Java binary when contain space (on Windows)

### DIFF
--- a/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
@@ -461,7 +461,13 @@ public class CommandlineTest
             throw new IOException( java.getAbsolutePath() + " doesn't exist" );
         }
 
-        createAndCallScript( dir, java.getAbsolutePath() + " -version" );
+        String javaBinStr = java.getAbsolutePath();
+        if ( Os.isFamily( Os.FAMILY_WINDOWS ) && javaBinStr.contains( " " ))
+        {
+            javaBinStr = "\"" + javaBinStr + "\"";
+        }
+        
+        createAndCallScript( dir, javaBinStr + " -version" );
     }
 
     public void testDollarSignInArgumentPath()


### PR DESCRIPTION
On Windows, the *echo.bat* generated test script should contain a quoted binary if it contains some space.