### PR TITLE
Back to Shell usage for Windows command line (+ minor Win UT fix)

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
@@ -139,7 +139,7 @@ public class Commandline
      * Create a new command line object.
      * Shell is autodetected from operating system
      *
-     * Shell usage is only desirable when generating code for remote execution.
+     * For Linux, shell usage is only desirable when generating code for remote execution.
      *
      * @param toProcess
      */
@@ -170,7 +170,7 @@ public class Commandline
      * Create a new command line object.
      * Shell is autodetected from operating system
      *
-     * Shell usage is only desirable when generating code for remote execution.
+     * For Linux, shell usage is only desirable when generating code for remote execution.
      */
     public Commandline( Shell shell )
     {
@@ -417,7 +417,7 @@ public class Commandline
     /**
      * Return an executable name, quoted for shell use.
      *
-     * Shell usage is only desirable when generating code for remote execution.
+     * For Linux, shell usage is only desirable when generating code for remote execution.
      *
      * @return Executable to be run, quoted for shell interpretation
      */
@@ -487,7 +487,7 @@ public class Commandline
         for ( Object o : envVars.keySet() )
         {
             String name = (String) o;
-            String value = (String) envVars.get( name );
+            String value = envVars.get( name );
             environmentVars[i] = name + "=" + value;
             i++;
         }
@@ -495,10 +495,16 @@ public class Commandline
     }
 
     /**
-     * Returns the executable and all defined arguments.
+     * Returns the executable and all defined arguments.<br/>
+     * For Windows Family, {@link Commandline#getShellCommandline()} is returned
      */
     public String[] getCommandline()
     {
+        if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
+        {
+            return getShellCommandline();
+        }
+        
         final String[] args = getArguments();
         String executable = getLiteralExecutable();
 
@@ -515,7 +521,7 @@ public class Commandline
     /**
      * Returns the shell, executable and all defined arguments.
      *
-     * Shell usage is only desirable when generating code for remote execution.
+     * For Linux, shell usage is only desirable when generating code for remote execution.
      */
     public String[] getShellCommandline()
     {
@@ -703,7 +709,7 @@ public class Commandline
     /**
      * Allows to set the shell to be used in this command line.
      *
-     * Shell usage is only desirable when generating code for remote execution.
+     * For Linux, shell usage is only desirable when generating code for remote execution.
      *
      * @param shell
      * @since 1.2
@@ -716,7 +722,7 @@ public class Commandline
     /**
      * Get the shell to be used in this command line.
      *
-     * Shell usage is only desirable when generating code for remote execution.
+     * For Linux, shell usage is only desirable when generating code for remote execution.
      * @since 1.2
      */
     public Shell getShell()

--- a/src/test/java/org/codehaus/plexus/util/DirectoryScannerTest.java
+++ b/src/test/java/org/codehaus/plexus/util/DirectoryScannerTest.java
@@ -164,8 +164,8 @@ public class DirectoryScannerTest
 
     private void assertAlwaysIncluded( List<String> included )
     {
-        assertTrue( included.contains( "aRegularDir/aRegularFile.txt" ) );
-        assertTrue( included.contains( "targetDir/targetFile.txt" ) );
+        assertTrue( included.contains( "aRegularDir" + File.separator + "aRegularFile.txt" ) );
+        assertTrue( included.contains( "targetDir" + File.separator + "targetFile.txt" ) );
         assertTrue( included.contains( "fileR.txt" ) );
         assertTrue( included.contains( "fileW.txt" ) );
         assertTrue( included.contains( "fileX.txt" ) );
@@ -183,8 +183,8 @@ public class DirectoryScannerTest
         ds.scan();
         List<String> included = Arrays.asList( ds.getIncludedFiles() );
         assertAlwaysIncluded( included );
-        assertTrue( included.contains( "symDir/targetFile.txt" ) );
-        assertTrue( included.contains( "symLinkToDirOnTheOutside/FileInDirOnTheOutside.txt" ) );
+        assertTrue( included.contains( "symDir" + File.separator + "targetFile.txt" ) );
+        assertTrue( included.contains( "symLinkToDirOnTheOutside" + File.separator + "FileInDirOnTheOutside.txt" ) );
         assertEquals( 11, included.size() );
 
         List<String> includedDirs = Arrays.asList( ds.getIncludedDirectories() );
@@ -195,7 +195,6 @@ public class DirectoryScannerTest
         assertTrue( includedDirs.contains( "targetDir" ) );
         assertEquals( 5, includedDirs.size() );
     }
-
 
     private void createTestDirectories()
         throws IOException


### PR DESCRIPTION
PR for #17 : Back to Shell usage for Windows command line (only). 
Allow embedded CMD command (echo, ...) and binary on PATH usage.
Regression since v3.0.15 (b38a1b3a4352303e4312b2bb601a0d7ec6e28f41 : improvement avoiding some shell injection).

----

In addition, minor UT fix on DirectoryScanner (were platform dependant)