### PR TITLE
Fix off issue #22 <?m2e execute onConfiguration?> fails if pom is big…

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -2469,7 +2469,7 @@ public class MXParser
         if(tokenize) posStart = pos;
         final int curLine = lineNumber;
         final int curColumn = columnNumber;
-        int piTargetStart = pos + bufAbsoluteStart;
+        int piTargetStart = pos;
         int piTargetEnd = -1;
         final boolean normalizeIgnorableWS = tokenize == true && roundtripSupported == false;
         boolean normalizedCR = false;
@@ -2495,7 +2495,7 @@ public class MXParser
                     seenQ = false;
                 } else {
                     if(piTargetEnd == -1 && isS(ch)) {
-                        piTargetEnd = pos - 1 + bufAbsoluteStart;
+                        piTargetEnd = pos - 1;
 
                         // [17] PITarget ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
                         if((piTargetEnd - piTargetStart) == 3) {
@@ -2520,7 +2520,7 @@ public class MXParser
                                 }
                                 parseXmlDecl(ch);
                                 if(tokenize) posEnd = pos - 2;
-                                final int off = piTargetStart - bufAbsoluteStart + 3;
+                                final int off = piTargetStart + 3;
                                 final int len = pos - 2 - off;
                                 xmlDeclContent = newString(buf, off, len);
                                 return false;
@@ -2575,8 +2575,6 @@ public class MXParser
             //throw new XmlPullParserException(
             //    "processing instruction must have PITarget name", this, null);
         }
-        piTargetStart -= bufAbsoluteStart;
-        piTargetEnd -= bufAbsoluteStart;
         if(tokenize) {
             posEnd = pos - 2;
             if(normalizeIgnorableWS) {

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -162,4 +162,57 @@ public class MXParserTest
         assertEquals( XmlPullParser.TEXT, parser.nextToken() );
         assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
     }
+
+    public void testSubsequentProcessingInstructionShort()
+            throws Exception
+    {
+        StringBuffer sb = new StringBuffer();
+
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.append("<project>");
+        sb.append("<!-- comment -->");
+        sb.append("<?m2e ignore?>");
+        sb.append("</project>");
+
+
+        MXParser parser = new MXParser();
+        parser.setInput( new StringReader( sb.toString() ) );
+
+
+        assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+        assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+        assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+    }
+
+    public void testSubsequentProcessingInstructionMoreThan8k()
+            throws Exception
+    {
+        StringBuffer sb = new StringBuffer();
+
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.append("<project>");
+
+        sb.append("<!-- ");
+
+        for (int i = 0; i < 1000; i++) {
+            sb.append("ten bytes ");
+        }
+
+        sb.append(" -->");
+        sb.append("<?m2e ignore?>");
+        sb.append("</project>");
+
+
+        MXParser parser = new MXParser();
+        parser.setInput( new StringReader( sb.toString() ) );
+
+
+        assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+        assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+        assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+    }
 }

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -194,13 +194,17 @@ public class MXParserTest
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         sb.append("<project>");
 
-        sb.append("<!-- ");
 
-        for (int i = 0; i < 1000; i++) {
-            sb.append("ten bytes ");
+        // add ten times 1000 chars as comment
+        for (int j = 0; j < 10; j++) {
+
+            sb.append("<!-- ");
+            for (int i = 0; i < 2000; i++) {
+                sb.append("ten bytes ");
+            }
+            sb.append(" -->");
         }
 
-        sb.append(" -->");
         sb.append("<?m2e ignore?>");
         sb.append("</project>");
 
@@ -211,6 +215,15 @@ public class MXParserTest
 
         assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
         assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
         assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
         assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
         assertEquals( XmlPullParser.END_TAG, parser.nextToken() );


### PR DESCRIPTION
… enough (8kb)

* fixed pom parser, as logic to check for x-m-l letters does not respected input tokenization
** all other occurences of <? are still ignored, but now: also when they appear behind READ_CHUNK_SIZE