### PR TITLE
JDK level compilation switched to v7 for Eclipse m2e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ limitations under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>6</javaVersion>
+    <javaVersion>7</javaVersion>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ limitations under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>7</javaVersion>
+    <javaVersion>6</javaVersion>
   </properties>
 
   <dependencies>
@@ -124,4 +124,19 @@ limitations under the License.
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <!-- See https://github.com/codehaus-plexus/plexus-utils/pull/27 -->
+      <!-- m2e Eclipse plugin doesn't respect the maven-enforcer-plugin 'requireJavaVersion' parameter  -->
+      <id>eclipse-only-jdk-version</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <properties>
+        <javaVersion>7</javaVersion>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Since commit ea5e38c17986be0786389111a4b8d9b99350c0a2, JDK v7 is used
for compilation.
Some class (Files, Path, ...) are now used and require JDK v7.
This change is mainly to link a JDK v7 when Eclipse m2e is used (v6 used
before, so compilation problem, manuel update required).