### PR TITLE
Files created on 1970-01-01 0000.0 are never copied when the target is not present.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 # No need for preliminary install step.

--- a/src/main/java/org/codehaus/plexus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/FileUtils.java
@@ -1164,7 +1164,7 @@ public class FileUtils
     public static boolean copyFileIfModified( final File source, final File destination )
         throws IOException
     {
-        if ( destination.lastModified() < source.lastModified() )
+        if ( isSourceNewerThanDestination( source, destination ) )
         {
             copyFile( source, destination );
 
@@ -2289,7 +2289,8 @@ public class FileUtils
     }
 
     /**
-     * <b>If wrappers is null or empty, the file will be copy only if to.lastModified() < from.lastModified()</b>
+     * <b>If wrappers is null or empty, the file will be copy only if to.lastModified() < from.lastModified(),
+     * if the files were both created on 1970-01-01 : 0000.00 </b>
      *
      * @param from the file to copy
      * @param to the destination file
@@ -2309,8 +2310,8 @@ public class FileUtils
     }
 
     /**
-     * <b>If wrappers is null or empty, the file will be copy only if to.lastModified() < from.lastModified() or if
-     * overwrite is true</b>
+     * <b>If wrappers is null or empty, the file will be copy only if to.lastModified() < from.lastModified(),
+     * if the files were both created on 1970-01-01 : 0000.00 or if overwrite is true</b>
      *
      * @param from the file to copy
      * @param to the destination file
@@ -2367,11 +2368,15 @@ public class FileUtils
         }
         else
         {
-            if ( to.lastModified() < from.lastModified() || overwrite )
+            if ( isSourceNewerThanDestination( from, to ) || overwrite )
             {
                 copyFile( from, to );
             }
         }
+    }
+
+    private static boolean isSourceNewerThanDestination( File source, File destination ) {
+        return ( destination.lastModified() == 0L && source.lastModified() == 0L ) || destination.lastModified() < source.lastModified();
     }
 
     /**

--- a/src/test/java/org/codehaus/plexus/util/FileUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/FileUtilsTest.java
@@ -439,6 +439,23 @@ public final class FileUtilsTest
         assertFalse( "Source file should not have been copied.", FileUtils.copyFileIfModified( source, destination ) );
     }
 
+    public void testCopyIfModifiedWhenSourceHasZeroDate()
+        throws Exception
+    {
+        FileUtils.forceMkdir( new File( getTestDirectory() + "/temp" ) );
+
+        // Source modified on 1970-1-1 0000.0
+        File source = new File( getTestDirectory(), "copy1.txt" );
+        FileUtils.copyFile( testFile1, source );
+        source.setLastModified( 0L );
+
+        // A non existing destination
+        File destination = new File( getTestDirectory(), "/temp/copy1.txt" );
+
+        // Should copy the source to the non existing destination.
+        assertTrue( "Source file should have been copied.", FileUtils.copyFileIfModified( source, destination ) );
+    }
+
     // forceDelete
 
     public void testForceDeleteAFile1()


### PR DESCRIPTION
This issue occurred to me when copying javascript from a node module.

These files were created on `1970-01-01 : 0000.00` and were not copied by the *maven-resources-plugin*. I was able to track the issue down to the:

`public static void copyFile( File from, File to, String encoding, FilterWrapper[] wrappers, boolean overwrite )	     public static void copyFile( File from, File to, String encoding, FilterWrapper[] wrappers, boolean overwrite ) throws IOException`

method.

The behaviour can be emulated with `touch -t 197001010000.00 test-1970-01-01.txt`.

The root cause is https://docs.oracle.com/javase/7/docs/api/java/io/File.html#lastModified() 

> ...or 0L if the file does not exist or if an I/O error occurs...

In this case the `lastModified` of the source file is equal to the `lastModified` of the non existing target file.