### PR TITLE
Revert usage of cmd on Windows

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
@@ -495,25 +495,19 @@ public class Commandline
     }
 
     /**
-     * Returns the executable and all defined arguments.<br/>
-     * For Windows Family, {@link Commandline#getShellCommandline()} is returned
+     * Returns the executable and all defined arguments.
      */
     public String[] getCommandline()
     {
-        if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
-        {
-            return getShellCommandline();
-        }
-
         final String[] args = getArguments();
-        String executable = getLiteralExecutable();
+        String executableTmp = getLiteralExecutable();
 
-        if ( executable == null )
+        if ( executableTmp == null )
         {
             return args;
         }
         final String[] result = new String[args.length + 1];
-        result[0] = executable;
+        result[0] = executableTmp;
         System.arraycopy( args, 0, result, 1, args.length );
         return result;
     }

--- a/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
@@ -93,10 +93,15 @@ public class CommandlineTest
         try
         {
             // Maven startup script on PATH is required for this test
+            String binary = "mvn";
+            if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
+            {
+                binary += ".cmd";
+            }
             Commandline cmd = new Commandline();
             cmd.setWorkingDirectory( baseDir );
-            cmd.setExecutable( "mvn" );
-            assertEquals( "mvn", cmd.getShell().getOriginalExecutable() );
+            cmd.setExecutable( binary );
+            assertEquals( binary, cmd.getShell().getOriginalExecutable() );
             cmd.createArg().setValue( "-version" );
             Process process = cmd.execute();
             String out = IOUtil.toString( process.getInputStream() );
@@ -116,11 +121,19 @@ public class CommandlineTest
         try
         {
             // allow it to detect the proper shell here.
+            String binary = "echo";
             Commandline cmd = new Commandline();
-            cmd.setWorkingDirectory( baseDir );
-            cmd.setExecutable( "echo" );
-            assertEquals( "echo", cmd.getShell().getOriginalExecutable() );
-            cmd.createArgument().setValue( "Hello" );
+            cmd.setWorkingDirectory( baseDir );            
+            if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
+            {
+                binary = "cmd";
+                cmd.createArg().setValue("/X");
+                cmd.createArg().setValue("/C");
+                cmd.createArg().setValue("echo");
+            }
+            cmd.setExecutable( binary );
+            assertEquals( binary, cmd.getShell().getOriginalExecutable() );
+            cmd.createArg().setValue( "Hello" );
 
             Process process = cmd.execute();
             assertEquals( "Hello", IOUtil.toString( process.getInputStream() ).trim() );
@@ -491,7 +504,10 @@ public class CommandlineTest
         cmd.setExecutable( "cat" );
         if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
         {
-            cmd.setExecutable( "dir" );
+            cmd.setExecutable( "cmd" );
+            cmd.createArg().setLine( "/X" );
+            cmd.createArg().setLine( "/C" );
+            cmd.createArg().setLine( "dir" );
         }
         cmd.setWorkingDirectory( dir );
         cmd.createArg().setLine( "test$1.txt" );


### PR DESCRIPTION
cf. #17 (comments from May 2018): Revert the usage of `cmd.exe` (on Windows), because prevents the destroy/kill launched by this way when `CTRL+C`.

For history: This Windows shell specific is removed since *plexus-utils* 3.0.15, except for 3.1.0.

On Windows, the usage of [cmd builtin](https://ss64.com/nt/syntax-internal.html) (like `echo`) or `.cmd` / `.bat` on *PATH* should be implemented by the client.