### PR TITLE
'issue-fix' branch merge (need openjdk7 instead of oraclejdk7 for Travis build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 # No need for preliminary install step.

--- a/src/main/java/org/codehaus/plexus/util/NioFiles.java
+++ b/src/main/java/org/codehaus/plexus/util/NioFiles.java
@@ -138,7 +138,7 @@ public class NioFiles
         throws IOException
     {
         Path copy = Files.copy( source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING,
-                                StandardCopyOption.COPY_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS );
+                                LinkOption.NOFOLLOW_LINKS );
         return copy.toFile();
     }
 


### PR DESCRIPTION
Travis [oraclejdk7](https://github.com/codehaus-plexus/plexus-utils/blob/master/.travis.yml#L3) support seems removed (see [here](https://github.com/travis-ci/travis-ci/issues/7884)), so all [2018 PR](https://github.com/codehaus-plexus/plexus-utils/pulls) builds fail.
@khmarbaise work in `issue-fix` branch should be merged (required for #39, #40, #41😏).