### PR TITLE
Changed to use openjdk7 instead of oraclejdk7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 # No need for preliminary install step.


### PR DESCRIPTION
Travis [oraclejdk7](https://github.com/codehaus-plexus/plexus-utils/blob/master/.travis.yml#L3) support seems removed (see [here](https://github.com/travis-ci/travis-ci/issues/7884)), so all [2018 PR](https://github.com/codehaus-plexus/plexus-utils/pulls) builds fail.
=> Partial inclusion of @khmarbaise work from `issue-fix` branch (required for #39, #40, #41).