### PR TITLE
Follow symlinks in NioFiles.copy

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/NioFiles.java
+++ b/src/main/java/org/codehaus/plexus/util/NioFiles.java
@@ -138,7 +138,7 @@ public class NioFiles
         throws IOException
     {
         Path copy = Files.copy( source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING,
-                                StandardCopyOption.COPY_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS );
+                                StandardCopyOption.COPY_ATTRIBUTES );
         return copy.toFile();
     }
 


### PR DESCRIPTION
Make copying using NIO and legacy IO consistent with respect to
following symlinks in source.

Fixes: #45