### PR TITLE
Solved issue #48.

### DIFF
--- a/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
@@ -103,7 +103,7 @@ public class CommandlineTest
             assertTrue( out.contains( "Apache Maven" ) );
             assertTrue( out.contains( "Maven home:" ) );
             assertTrue( out.contains( "Java version:" ) );
-            assertTrue( out.contains( "Java home:" ) );
+            assertTrue( out.contains( "OS name:" ) );
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
Changed text to assert by "OS name:", which appears in both 3.5.x Maven
versions and Maven 3.6.0.