### PR TITLE
#51: PrettyPrintXMLWriter fails with a java.util.NoSuchElementException (Java 1.7 only)

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/PrettyPrintXMLWriter.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/PrettyPrintXMLWriter.java
@@ -305,8 +305,7 @@ public class PrettyPrintXMLWriter
             finishTag();
 
             // see issue #51: https://github.com/codehaus-plexus/plexus-utils/issues/51
-            // Rationale: removed the element into a variable first, and only THEN
-            // concatenate the string.
+            // Rationale: replaced 1 write() with string concatenations with 3 write()
             // (this avoids the string concatenation optimization bug detected in Java 7)
             // TODO: change the below code to a more efficient expression when the library
             // be ready to target Java 8.

--- a/src/main/java/org/codehaus/plexus/util/xml/PrettyPrintXMLWriter.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/PrettyPrintXMLWriter.java
@@ -304,7 +304,14 @@ public class PrettyPrintXMLWriter
         {
             finishTag();
 
-            write( "</" + elementStack.removeLast() + ">" );
+            // see issue #51: https://github.com/codehaus-plexus/plexus-utils/issues/51
+            // Rationale: removed the element into a variable first, and only THEN
+            // concatenate the string.
+            // (this avoids the string concatenation optimization bug detected in Java 7)
+            // TODO: change the below code to a more efficient expression when the library
+            // be ready to target Java 8.
+            String element = elementStack.removeLast();
+            write( "</" + element + ">" );
         }
 
         readyForNewLine = true;

--- a/src/main/java/org/codehaus/plexus/util/xml/PrettyPrintXMLWriter.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/PrettyPrintXMLWriter.java
@@ -310,8 +310,9 @@ public class PrettyPrintXMLWriter
             // (this avoids the string concatenation optimization bug detected in Java 7)
             // TODO: change the below code to a more efficient expression when the library
             // be ready to target Java 8.
-            String element = elementStack.removeLast();
-            write( "</" + element + ">" );
+            write( "</" );
+            write( elementStack.removeLast() );
+            write( ">" );
         }
 
         readyForNewLine = true;


### PR DESCRIPTION
Changed concatenation expression in endElement() method to avoid the Java 7 bug.
Added test to detect if the bug is present.