### PR TITLE
#57 Uncaught IllegalArgumentException due to malformed unicode entity ref

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -2664,14 +2664,16 @@ public class MXParser
         entityRefName = null;
         posStart = pos;
         char ch = more();
-        StringBuilder sb16 = new StringBuilder();
-        StringBuilder sb10 = new StringBuilder();
         if ( ch == '#' )
         {
             // parse character reference
+
             char charRef = 0;
             ch = more();
-            if ( ch == 'x' )
+            StringBuilder sb = new StringBuilder();
+            boolean isHex = ( ch == 'x' );
+
+            if ( isHex )
             {
                 // encoded in hex
                 while ( true )
@@ -2680,17 +2682,17 @@ public class MXParser
                     if ( ch >= '0' && ch <= '9' )
                     {
                         charRef = (char) ( charRef * 16 + ( ch - '0' ) );
-                        sb16.append( ch );
+                        sb.append( ch );
                     }
                     else if ( ch >= 'a' && ch <= 'f' )
                     {
                         charRef = (char) ( charRef * 16 + ( ch - ( 'a' - 10 ) ) );
-                        sb16.append( ch );
+                        sb.append( ch );
                     }
                     else if ( ch >= 'A' && ch <= 'F' )
                     {
                         charRef = (char) ( charRef * 16 + ( ch - ( 'A' - 10 ) ) );
-                        sb16.append( ch );
+                        sb.append( ch );
                     }
                     else if ( ch == ';' )
                     {
@@ -2711,7 +2713,7 @@ public class MXParser
                     if ( ch >= '0' && ch <= '9' )
                     {
                         charRef = (char) ( charRef * 10 + ( ch - '0' ) );
-                        sb10.append( ch );
+                        sb.append( ch );
                     }
                     else if ( ch == ';' )
                     {
@@ -2726,39 +2728,19 @@ public class MXParser
                 }
             }
             posEnd = pos - 1;
-            if ( sb16.length() > 0 )
-            {
-                try
-                {
-                    charRefOneCharBuf = toChars( Integer.parseInt( sb16.toString(), 16 ) );
-                }
-                catch ( IllegalArgumentException e )
-                {
-                    throw new XmlPullParserException( "character reference (with hex value " + sb16.toString()
-                        + ") is invalid", this, null );
-                }
-
-                if ( tokenize )
-                {
-                    text = newString( charRefOneCharBuf, 0, charRefOneCharBuf.length );
-                }
-                return charRefOneCharBuf;
-            }
-
             try
             {
-                toChars( Integer.parseInt( sb10.toString(), 10 ) );
+                charRefOneCharBuf = toChars( Integer.parseInt( sb.toString(), isHex ? 16 : 10 ) );
             }
             catch ( IllegalArgumentException e )
             {
-                throw new XmlPullParserException( "character reference (with decimal value " + sb10.toString()
-                    + ") is invalid", this, null );
+                throw new XmlPullParserException( "character reference (with " + ( isHex ? "hex" : "decimal" )
+                    + " value " + sb.toString() + ") is invalid", this, null );
             }
 
-            charRefOneCharBuf[0] = charRef;
             if ( tokenize )
             {
-                text = newString( charRefOneCharBuf, 0, 1 );
+                text = newString( charRefOneCharBuf, 0, charRefOneCharBuf.length );
             }
             return charRefOneCharBuf;
         }
@@ -4031,7 +4013,7 @@ public class MXParser
     {
         // Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
         return codePoint == 0x9 || codePoint == 0xA || codePoint == 0xD || ( 0x20 <= codePoint && codePoint <= 0xD7FF )
-            || ( 0xE000 <= codePoint && codePoint <= 0xFFFD ) || ( 0x10000 <= codePoint && codePoint <= 0X10FFFF );
+            || ( 0xE000 <= codePoint && codePoint <= 0xFFFD ) || ( 0x10000 <= codePoint && codePoint <= 0x10FFFF );
     }
 
     private static boolean isSupplementaryCodePoint( int codePoint )

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -179,6 +179,49 @@ public class MXParserTest
     }
 
     @Test
+    public void testValidCharacterReferenceHexa()
+        throws Exception
+    {
+        MXParser parser = new MXParser();
+        String input = "<root>&#x9;&#xA;&#xD;&#x20;&#x200;&#xD7FF;&#xE000;&#xFFA2;&#xFFFD;&#x10000;&#x10FFFD;&#x10FFFF;</root>";
+        parser.setInput( new StringReader( input ) );
+
+        try
+        {
+            assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0x9, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0xA, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0xD, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0x20, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0x200, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0xD7FF, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0xE000, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0xFFA2, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0xFFFD, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0x10000, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0x10FFFD, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 0x10FFFF, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+        }
+        catch ( XmlPullParserException e )
+        {
+            fail( "Should success since the input represents all legal character references" );
+        }
+    }
+
+    @Test
     public void testInvalidCharacterReferenceDecimal()
         throws Exception
     {
@@ -195,6 +238,50 @@ public class MXParserTest
         catch ( XmlPullParserException e )
         {
             assertTrue( e.getMessage().contains( "character reference (with decimal value 1114112) is invalid" ) );
+        }
+    }
+
+    @Test
+    public void testValidCharacterReferenceDecimal()
+        throws Exception
+    {
+        MXParser parser = new MXParser();
+        String input =
+            "<root>&#9;&#10;&#13;&#32;&#512;&#55295;&#57344;&#65442;&#65533;&#65536;&#1114109;&#1114111;</root>";
+        parser.setInput( new StringReader( input ) );
+
+        try
+        {
+            assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 9, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 10, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 13, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 32, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 512, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 55295, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 57344, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 65442, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 65533, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 65536, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 1114109, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            assertEquals( 1114111, parser.getText().codePointAt( 0 ) );
+            assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+        }
+        catch ( XmlPullParserException e )
+        {
+            fail( "Should success since the input represents all legal character references" );
         }
     }
 

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -17,6 +17,8 @@ package org.codehaus.plexus.util.xml.pull;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -154,6 +156,46 @@ public class MXParserTest
         assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
         assertEquals( "\u0159", parser.getText() );
         assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+    }
+
+    @Test
+    public void testInvalidCharacterReferenceHexa()
+        throws Exception
+    {
+        MXParser parser = new MXParser();
+        String input = "<root>&#x110000;</root>";
+        parser.setInput( new StringReader( input ) );
+
+        try
+        {
+            assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            fail( "Should fail since &#x110000; is an illegal character reference" );
+        }
+        catch ( XmlPullParserException e )
+        {
+            assertTrue( e.getMessage().contains( "character reference (with hex value 110000) is invalid" ) );
+        }
+    }
+
+    @Test
+    public void testInvalidCharacterReferenceDecimal()
+        throws Exception
+    {
+        MXParser parser = new MXParser();
+        String input = "<root>&#1114112;</root>";
+        parser.setInput( new StringReader( input ) );
+
+        try
+        {
+            assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+            assertEquals( XmlPullParser.ENTITY_REF, parser.nextToken() );
+            fail( "Should fail since &#1114112; is an illegal character reference" );
+        }
+        catch ( XmlPullParserException e )
+        {
+            assertTrue( e.getMessage().contains( "character reference (with decimal value 1114112) is invalid" ) );
+        }
     }
 
     @Test


### PR DESCRIPTION
- Added a more readable error message by means of a
XmlPullParserException.
- Improved validation of the numeric character reference, according to
XML 1.0 spec. (https://www.w3.org/TR/REC-xml/#NT-Char)