### PR TITLE
remove redundant File.length() check to fix race condition

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/FileUtils.java
@@ -1080,12 +1080,6 @@ public class FileUtils
         mkdirsFor( destination );
 
         doCopyFile( source, destination );
-
-        if ( source.length() != destination.length() )
-        {
-            String message = "Failed to copy full contents from " + source + " to " + destination;
-            throw new IOException( message );
-        }
     }
 
     private static void doCopyFile( File source, File destination )


### PR DESCRIPTION
See https://github.com/codehaus-plexus/plexus-utils/issues/47