### PR TITLE
Improve speed for Xpp3Dom clone / merge operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,18 @@ limitations under the License.
         <version>1.1</version>
         <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.21</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/codehaus/plexus/util/xml/Xpp3Dom.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/Xpp3Dom.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -272,6 +273,39 @@ public class Xpp3Dom
         }
     }
 
+    public List<Xpp3Dom> getChildrenAsList( String name )
+    {
+        if ( null == childList )
+        {
+            return Collections.emptyList();
+        }
+        else
+        {
+            ArrayList<Xpp3Dom> children = null;
+
+            for ( Xpp3Dom configuration : childList )
+            {
+                if ( name.equals( configuration.getName() ) )
+                {
+                    if ( children == null )
+                    {
+                        children = new ArrayList<Xpp3Dom>();
+                    }
+                    children.add( configuration );
+                }
+            }
+
+            if ( children != null )
+            {
+                return children;
+            }
+            else
+            {
+                return Collections.emptyList();
+            }
+        }
+    }
+
     public int getChildCount()
     {
         if ( null == childList )
@@ -460,10 +494,10 @@ public class Xpp3Dom
                         {
                             continue;
                         }
-                        Xpp3Dom[] dominantChildren = dominant.getChildren( recChild.name );
-                        if ( dominantChildren.length > 0 )
+                        List<Xpp3Dom> dominantChildren = dominant.getChildrenAsList( recChild.name );
+                        if ( dominantChildren.size() > 0 )
                         {
-                            commonChildren.put( recChild.name, Arrays.asList( dominantChildren ).iterator() );
+                            commonChildren.put( recChild.name, dominantChildren.iterator() );
                         }
                     }
 

--- a/src/main/java/org/codehaus/plexus/util/xml/Xpp3Dom.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/Xpp3Dom.java
@@ -247,38 +247,10 @@ public class Xpp3Dom
 
     public Xpp3Dom[] getChildren( String name )
     {
-        if ( null == childList )
-        {
-            return EMPTY_DOM_ARRAY;
-        }
-        else
-        {
-            ArrayList<Xpp3Dom> children = null;
-
-            for ( Xpp3Dom configuration : childList )
-            {
-                if ( name.equals( configuration.getName() ) )
-                {
-                    if ( children == null )
-                    {
-                        children = new ArrayList<Xpp3Dom>();
-                    }
-                    children.add( configuration );
-                }
-            }
-
-            if ( children != null )
-            {
-                return children.toArray( EMPTY_DOM_ARRAY );
-            }
-            else
-            {
-                return EMPTY_DOM_ARRAY;
-            }
-        }
+        return getChildrenAsList( name ).toArray( EMPTY_DOM_ARRAY );
     }
 
-    public List<Xpp3Dom> getChildrenAsList( String name )
+    private List<Xpp3Dom> getChildrenAsList( String name )
     {
         if ( null == childList )
         {

--- a/src/main/java/org/codehaus/plexus/util/xml/Xpp3Dom.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/Xpp3Dom.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 /**
@@ -211,12 +212,16 @@ public class Xpp3Dom
 
     public Xpp3Dom getChild( String name )
     {
-        for ( int i = childList.size() - 1; i >= 0; i-- )
+        if ( name != null )
         {
-            Xpp3Dom child = childList.get( i );
-            if ( name.equals( child.getName() ) )
+            ListIterator<Xpp3Dom> it = childList.listIterator( childList.size() );
+            while ( it.hasPrevious() )
             {
-                return child;
+                Xpp3Dom child = it.previous();
+                if ( name.equals( child.getName() ) )
+                {
+                    return child;
+                }
             }
         }
         return null;

--- a/src/test/java/org/codehaus/plexus/util/xml/Xpp3DomPerfTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/Xpp3DomPerfTest.java
@@ -1,0 +1,78 @@
+package org.codehaus.plexus.util.xml;
+
+/*
+ * Copyright The Codehaus Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.concurrent.TimeUnit;
+
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+public class Xpp3DomPerfTest
+{
+    @State(Scope.Benchmark)
+    static public class AdditionState {
+        Xpp3Dom dom1;
+        Xpp3Dom dom2;
+
+        @Setup(Level.Iteration)
+        public void setUp() throws IOException, XmlPullParserException {
+            String testDom = "<configuration><items thing='blah'><item>one</item><item>two</item></items></configuration>";
+            dom1 = Xpp3DomBuilder.build( new StringReader( testDom ) );
+            dom2 = new Xpp3Dom( dom1 );
+        }
+    }
+
+
+    @Benchmark
+    public Xpp3Dom benchmarkClone(AdditionState state)
+    {
+        return new Xpp3Dom( state.dom1 );
+    }
+
+    @Benchmark
+    public void benchmarkMerge(AdditionState state)
+    {
+        Xpp3Dom.mergeXpp3Dom( state.dom1, state.dom2 );
+    }
+
+    public static void main(String... args) throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .measurementIterations(3)
+                .measurementTime(TimeValue.milliseconds(3000))
+                .forks(1)
+                .build();
+        new Runner(opts).run();
+    }
+}


### PR DESCRIPTION
```
Before:
Benchmark                        Mode  Cnt     Score     Error   Units
Xpp3DomPerfTest.benchmarkClone  thrpt    3  4367,683 ± 361,351  ops/ms
Xpp3DomPerfTest.benchmarkMerge  thrpt    3  3891,716 ± 289,711  ops/ms

After:
Benchmark                        Mode  Cnt     Score     Error   Units
Xpp3DomPerfTest.benchmarkClone  thrpt    3  7062,259 ± 713,564  ops/ms
Xpp3DomPerfTest.benchmarkMerge  thrpt    3  4941,132 ± 446,558  ops/ms
```