### PR TITLE
Add public String[] getRawCommandline() to avoid OS dependency code in unit tests

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
@@ -488,6 +488,15 @@ public class Commandline
             return getShellCommandline();
         }
 
+        return getRawCommandline();
+    }
+
+    /**
+     * Returns the executable and all defined arguments.<br>
+     * 
+     */
+    public String[] getRawCommandline()
+    {
         final String[] args = getArguments();
         String executable = getLiteralExecutable();
 
@@ -501,7 +510,7 @@ public class Commandline
         return result;
     }
 
-    /**
+	/**
      * Returns the shell, executable and all defined arguments. Shell usage is only desirable when generating code for
      * remote execution.
      */


### PR DESCRIPTION
Hi

In order to avoid such bad OS dependency code as below
```
        String[] commandLine = cl.getCommandline();

        if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
        {
            if ( Os.isFamily( Os.FAMILY_WIN9X ) )
            {
            	assertArrayEquals( new String[] { "command.com", "/C", "\"gcc -Ip1 -Ip2 -Isp1 -Isp2 -o object.o -c source.c\"" },  commandLine );
            }
            else
            {
               	assertArrayEquals( new String[] { "cmd.exe", "/X", "/C", "\"gcc -Ip1 -Ip2 -Isp1 -Isp2 -o object.o -c source.c\"" },  commandLine );
            }
        }
        else
        {
            assertArrayEquals( new String[] { "gcc", "-Ip1", "-Ip2", "-Isp1", "-Isp2", simpleArgv[0], simpleArgv[1],
                    simpleArgv[2], simpleArgv[3] }, commandLine );
        }
```
this PR introduces the function `public String[] getRawCommandline()` so that the above code be reformated as
```
        String[] commandLine = cl.getRawCommandline();
        assertArrayEquals( new String[] { "gcc", "-Ip1", "-Ip2", "-Isp1", "-Isp2", simpleArgv[0], simpleArgv[1],
                    simpleArgv[2], simpleArgv[3] }, commandLine );
```
