### PR TITLE
Add fix for overflow error in MXParser buffer sizing

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -3658,7 +3658,7 @@ public class MXParser
                 buf = newBuf;
                 if ( bufLoadFactor > 0 )
                 {
-                    // Include fix for https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228
+                    // Include a fix for https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228
                     bufSoftLimit = (int) (bufferLoadFactor * buf.length);
                 }
 

--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -401,9 +401,11 @@ public class MXParser
     protected int bufLoadFactor = 95; // 99%
     // protected int bufHardLimit; // only matters when expanding
 
+    protected float bufferLoadFactor = bufLoadFactor / 100f;
+
     protected char buf[] = new char[Runtime.getRuntime().freeMemory() > 1000000L ? READ_CHUNK_SIZE : 256];
 
-    protected int bufSoftLimit = ( bufLoadFactor * buf.length ) / 100; // desirable size of buffer
+    protected int bufSoftLimit = (int) (bufferLoadFactor * buf.length); // desirable size of buffer
 
     protected boolean preventBufferCompaction;
 
@@ -3657,7 +3659,7 @@ public class MXParser
                 if ( bufLoadFactor > 0 )
                 {
                     // Include fix for https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228
-                    bufSoftLimit = (int) ((((long) bufLoadFactor) * buf.length) / 100);
+                    bufSoftLimit = (int) (bufferLoadFactor * buf.length);
                 }
 
             }

--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -3656,7 +3656,8 @@ public class MXParser
                 buf = newBuf;
                 if ( bufLoadFactor > 0 )
                 {
-                    bufSoftLimit = ( bufLoadFactor * buf.length ) / 100;
+                    // Include fix for https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228
+                    bufSoftLimit = (int) ((((long) bufLoadFactor) * buf.length) / 100);
                 }
 
             }

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -391,6 +391,23 @@ public class MXParserTest
         assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
     }
 
+    @Test
+    public void testFillBuf_NoOverflow()
+        throws Exception
+    {
+        MXParser parser = new MXParser();
+        parser.reader = new StringReader("testFillBuf_NoOverflow");
+        parser.bufEnd = 15941364;
+        parser.buf = new char[16777216];
+
+        parser.fillBuf();
+
+        // Without this fix
+        // https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228
+        // the integer value overflows to -11072962
+        assertTrue(parser.bufSoftLimit >= 0);
+    }
+
     public void testMalformedProcessingInstructionAfterTag()
         throws Exception
     {

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -392,20 +392,25 @@ public class MXParserTest
     }
 
     @Test
-    public void testFillBuf_NoOverflow()
+    public void testLargeText_NoOverflow()
         throws Exception
     {
-        MXParser parser = new MXParser();
-        parser.reader = new StringReader("testFillBuf_NoOverflow");
-        parser.bufEnd = 15941364;
-        parser.buf = new char[16777216];
-
-        parser.fillBuf();
-
-        // Without this fix
+        StringBuffer sb = new StringBuffer();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.append("<largetextblock>");
+        // Anything above 33,554,431 would fail without a fix for
         // https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228
-        // the integer value overflows to -11072962
-        assertTrue(parser.bufSoftLimit >= 0);
+        // with java.io.IOException: error reading input, returned 0
+        sb.append(new String(new char[33554432]));
+        sb.append("</largetextblock>");
+
+        MXParser parser = new MXParser();
+        parser.setInput(new StringReader(sb.toString()));
+
+        assertEquals(XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken());
+        assertEquals(XmlPullParser.START_TAG, parser.nextToken());
+        assertEquals(XmlPullParser.TEXT, parser.nextToken());
+        assertEquals(XmlPullParser.END_TAG, parser.nextToken());
     }
 
     public void testMalformedProcessingInstructionAfterTag()


### PR DESCRIPTION
This is to include this fix (original URL is down so referencing using a wayback machine link, also copied below) which helps prevent `bufSoftLimit` being updated to an integer overflowed value.

https://web.archive.org/web/20070831191548/http://www.extreme.indiana.edu/bugzilla/show_bug.cgi?id=228

```
When reading a very large text element (~34MB), MXParser gets itself into a bad
state and throws an IOException.  Here is the stack trace:

java.io.IOException: error reading input, returned 0
        at org.xmlpull.mxp1.MXParser.fillBuf(MXParser.java:3019)
        at org.xmlpull.mxp1.MXParser.more(MXParser.java:3025)
        at org.xmlpull.mxp1.MXParser.nextImpl(MXParser.java:1384)
        at org.xmlpull.mxp1.MXParser.next(MXParser.java:1093)

I traced the calls to Reader.read(char[], int, int), and here's what I saw:

...
read(char[33554432], 33529338, 8192): 8192
read(char[33554432], 33537530, 8192): 8192
read(char[33554432], 33545722, 8192): 8192
read(char[33554432], 33553914, 518): 518
read(char[33554432], 33554432, 0): 0
java.io.IOException: error reading input, returned 0

I think the problem is that the calculation of bufSoftLimit on line 2952 is
overflowing and becoming negative:

bufSoftLimit = ( bufLoadFactor * buf.length ) /100;

A solution would be to do the multiplication using 64-bit longs:

bufSoftLimit = (int) (( ((long) bufLoadFactor) * buf.length ) /100);

Or test for large values and change the order of operations to avoid overflow:

if (buf.length > 10000000) {
  bufSoftLimit = (buf.length / 100) * bufLoadFactor;
} else {
  bufSoftLimit = (bufLoadFactor * buf.length) / 100;
}

I am using version 1.1.3.4.M.
------- Comment #1 From Aleksander Slominski 2005-08-11 17:48:46 -------
interesting - i have nver seens this before! you musthave very large text
section in XML.

fixed in CVS and just cut a new release wit this fix (1.1.3.4.O) available in 
http://www.extreme.indiana.edu/dist/java-repository/xpp3/ 

thanks!
```