### PR TITLE
new feature  FileUtils.linkFile(source, destination)

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/FileUtils.java
@@ -1059,6 +1059,38 @@ public class FileUtils
     }
 
     /**
+     * Link file from destination to source. The directories up to <code>destination</code> will be created if they
+     * don't already exist. <code>destination</code> will be overwritten if it already exists.
+     *
+     * @param source An existing non-directory <code>File</code> to link to.
+     * @param destination A non-directory <code>File</code> becoming the link (possibly overwriting).
+     * @throws IOException if <code>source</code> does not exist, <code>destination</code> cannot be created, or an
+     *             IO error occurs during linking.
+     * @throws java.io.FileNotFoundException if <code>destination</code> is a directory (use
+     *             {@link #copyFileToDirectory}).
+     */
+    public static void linkFile( final File source, final File destination )
+        throws IOException
+    {
+        // check source exists
+        if ( !source.exists() )
+        {
+            final String message = "File " + source + " does not exist";
+            throw new IOException( message );
+        }
+
+        // check source != destination, see PLXUTILS-10
+        if ( source.getCanonicalPath().equals( destination.getCanonicalPath() ) )
+        {
+            // if they are equal, we can exit the method without doing any work
+            return;
+        }
+        mkdirsFor( destination );
+
+        NioFiles.createSymbolicLink( destination, source );
+    }
+
+    /**
      * Copy file from source to destination only if source timestamp is later than the destination timestamp. The
      * directories up to <code>destination</code> will be created if they don't already exist. <code>destination</code>
      * will be overwritten if it already exists.

--- a/src/test/java/org/codehaus/plexus/util/FileUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/FileUtilsTest.java
@@ -34,6 +34,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import org.junit.Before;
@@ -426,6 +427,50 @@ public final class FileUtilsTest
         FileUtils.copyFile( testFile1, destination );
         assertTrue( "Check Exist", destination.exists() );
         assertTrue( "Check Full copy", destination.length() == testFile2Size );
+    }
+
+    // linkFile
+    @Test
+    public void testLinkFile1()
+        throws Exception
+    {
+        final File destination = new File( getTestDirectory(), "link1.txt" );
+        FileUtils.linkFile( testFile1, destination );
+        assertTrue( "Check Exist", destination.exists() );
+        assertTrue( "Check File length", destination.length() == testFile1Size );
+        assertTrue( "Check is link", Files.isSymbolicLink(destination.toPath()));
+    }
+
+    @Test
+    public void testLinkFile2()
+        throws Exception
+    {
+        final File destination = new File( getTestDirectory(), "link2.txt" );
+        FileUtils.linkFile( testFile1, destination );
+        assertTrue( "Check Exist", destination.exists() );
+        assertTrue( "Check File length", destination.length() == testFile2Size );
+        assertTrue( "Check is link", Files.isSymbolicLink(destination.toPath()));
+    }
+
+    /**
+     * ensure we create directory tree for destination
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLinkFile3()
+        throws Exception
+    {
+        File destDirectory = new File( getTestDirectory(), "foo/bar/testlink" );
+        if ( destDirectory.exists() )
+        {
+            destDirectory.delete();
+        }
+        final File destination = new File( destDirectory, "link2.txt" );
+        FileUtils.linkFile( testFile1, destination );
+        assertTrue( "Check Exist", destination.exists() );
+        assertTrue( "Check File length", destination.length() == testFile2Size );
+        assertTrue( "Check is link", Files.isSymbolicLink(destination.toPath()));
     }
 
     // copyFileIfModified


### PR DESCRIPTION
New method `FileUtils.linkFile` does the same as `FileUtils.copyFile`, but instead of actually moving the file content, it just produces a symbolic link.

Unit tests are exactly the same as for `FileUtils.copyFile` but in addition check that the result is really a symlink.