### PR TITLE
Revert usage of cmd on Windows

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/Commandline.java
@@ -428,19 +428,18 @@ public class Commandline implements Cloneable {
     }
 
     /**
+     * Warning: For built-in commands like 'echo' on {@link Os#FAMILY_WINDOWS}, use <code>cmd /X /C echo</code>
+     * @deprecated Use {@link org.codehaus.plexus.util.cli.Commandline#getRawCommandline()} method instead.
      * @return Returns the executable and all defined arguments.
-     *      For Windows Family, {@link Commandline#getShellCommandline()} is returned
      */
+    @Deprecated
     public String[] getCommandline() {
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            return getShellCommandline();
-        }
-
         return getRawCommandline();
     }
 
     /**
-     * Returns the executable and all defined arguments.
+     * Returns the executable and all defined arguments.<br>
+     * Warning: For built-in commands like 'echo' on {@link Os#FAMILY_WINDOWS}, use <code>cmd /X /C echo</code>
      * @return the command line as array not escaped neither quoted
      */
     public String[] getRawCommandline() {
@@ -494,7 +493,7 @@ public class Commandline implements Cloneable {
     }
 
     public int size() {
-        return getCommandline().length;
+        return getRawCommandline().length;
     }
 
     @Override
@@ -582,7 +581,7 @@ public class Commandline implements Cloneable {
 
         try {
             if (workingDir == null) {
-                process = Runtime.getRuntime().exec(getCommandline(), environment, workingDir);
+                process = Runtime.getRuntime().exec(getRawCommandline(), environment, workingDir);
             } else {
                 if (!workingDir.exists()) {
                     throw new CommandLineException(

--- a/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
@@ -78,10 +78,14 @@ class CommandlineTest {
     @Test
     void executeBinaryOnPath() throws Exception {
         // Maven startup script on PATH is required for this test
+        String binary = "mvn";
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            binary += ".cmd";
+        }
         Commandline cmd = new Commandline();
         cmd.setWorkingDirectory(baseDir);
-        cmd.setExecutable("mvn");
-        assertEquals("mvn", cmd.getShell().getOriginalExecutable());
+        cmd.setExecutable(binary);
+        assertEquals(binary, cmd.getShell().getOriginalExecutable());
         cmd.createArg().setValue("-version");
         Process process = cmd.execute();
         String out = IOUtil.toString(process.getInputStream());
@@ -94,11 +98,19 @@ class CommandlineTest {
     @Test
     void execute() throws Exception {
         // allow it to detect the proper shell here.
+        String executable = "echo";
         Commandline cmd = new Commandline();
         cmd.setWorkingDirectory(baseDir);
-        cmd.setExecutable("echo");
-        assertEquals("echo", cmd.getShell().getOriginalExecutable());
-        cmd.createArgument().setValue("Hello");
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            cmd.createArg().setValue("Hello");
+            executable = "cmd";
+            cmd.createArg().setValue("/X");
+            cmd.createArg().setValue("/C");
+            cmd.createArg().setValue("echo");
+        }
+        cmd.setExecutable(executable);
+        assertEquals(executable, cmd.getShell().getOriginalExecutable());
+        cmd.createArg().setValue("Hello");
 
         Process process = cmd.execute();
         assertEquals("Hello", IOUtil.toString(process.getInputStream()).trim());
@@ -385,7 +397,10 @@ class CommandlineTest {
         cmd.getShell().setQuotedArgumentsEnabled(true);
         cmd.setExecutable("cat");
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            cmd.setExecutable("dir");
+            cmd.setExecutable("cmd");
+            cmd.createArg().setLine("/X");
+            cmd.createArg().setLine("/C");
+            cmd.createArg().setLine("dir");
         }
         cmd.setWorkingDirectory(dir);
         cmd.createArg().setLine("test$1.txt");


### PR DESCRIPTION
This PR is an update of old previous staling PR #41

----

cf. #17 (comments from May 2018): Revert the usage of `cmd.exe` (on Windows), because prevents the destroy/kill launched by this way when `CTRL+C`.

For history: This Windows shell specific is removed since *plexus-utils* 3.0.15, except for 3.1.0.

On Windows, the usage of [cmd builtin](https://ss64.com/nt/syntax-internal.html) (like `echo`) or `.cmd` / `.bat` on *PATH* should be implemented by the client/user.

----

Another approach could be a dedicated option: See #110 