### PR TITLE
NIO 9

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/IOUtil.java
+++ b/src/main/java/org/codehaus/plexus/util/IOUtil.java
@@ -156,7 +156,7 @@ public final class IOUtil
     public static void copy( final InputStream input, final OutputStream output )
         throws IOException
     {
-        copy( input, output, DEFAULT_BUFFER_SIZE );
+        input.transferTo( output );
     }
 
     /**


### PR DESCRIPTION
Work in progress: Using NIO 9 to allow better offloading / performance. PR stays in draft state until Plexus Utils is allowed to use Java 9 APIs.