### PR TITLE
Not building on JRE 7 anymore, since we pushed minimum to JRE 8

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [7, 8, 11, 14, 15, 16-ea]
+        java: [8, 11, 14, 15, 16-ea]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
As we have recently pushed the minimum JRE version from 7 to 8, we must not build on JRE 7 anymore, as using any JRE 8 API would definitively break CI then!