### PR TITLE
Invalid pi

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -460,7 +460,7 @@ public class MXParser
         // System.out.println("reset() called");
         location = null;
         lineNumber = 1;
-        columnNumber = 0;
+        columnNumber = 1;
         seenRoot = false;
         reachedEnd = false;
         eventType = START_DOCUMENT;
@@ -3082,7 +3082,7 @@ public class MXParser
                     {
                         // seenPITarget && !seenQ
                         throw new XmlPullParserException( "processing instruction started on line " + curLine
-                            + " and column " + curColumn + " was not closed", this, null );
+                            + " and column " + (curColumn -2) + " was not closed", this, null );
                     }
                 }
                 else if ( ch == '<' )

--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -3084,6 +3084,10 @@ public class MXParser
                         throw new XmlPullParserException( "processing instruction started on line " + curLine
                             + " and column " + (curColumn -2) + " was not closed", this, null );
                     }
+                    else
+                    {
+                        seenInnerTag = false;
+                    }
                 }
                 else if ( ch == '<' )
                 {

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -287,6 +287,35 @@ public class MXParserTest
     }
 
     @Test
+    public void testParserPosition()
+            throws Exception
+    {
+        String input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!-- A --> \n <!-- B --><test>\tnnn</test>\n<!-- C\nC -->";
+
+        MXParser parser = new MXParser();
+        parser.setInput( new StringReader( input ) );
+
+        assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+        assertPosition( 1, 39, parser );
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertPosition( 1, 49, parser );
+        assertEquals( XmlPullParser.IGNORABLE_WHITESPACE, parser.nextToken() );
+        assertPosition( 2, 3, parser ); // end when next token starts
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertPosition( 2, 12, parser );
+        assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+        assertPosition( 2, 18, parser );
+        assertEquals( XmlPullParser.TEXT, parser.nextToken() );
+        assertPosition( 2, 23, parser ); // end when next token starts
+        assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+        assertPosition( 2, 29, parser );
+        assertEquals( XmlPullParser.IGNORABLE_WHITESPACE, parser.nextToken() );
+        assertPosition( 3, 2, parser ); // end when next token starts
+        assertEquals( XmlPullParser.COMMENT, parser.nextToken() );
+        assertPosition( 4, 6, parser );
+    }
+
+    @Test
     public void testProcessingInstruction()
         throws Exception
     {
@@ -517,7 +546,7 @@ public class MXParserTest
         }
         catch ( XmlPullParserException ex )
         {
-            assertTrue( ex.getMessage().contains( "processing instruction started on line 1 and column 2 was not closed" ) );
+            assertTrue( ex.getMessage().contains( "processing instruction started on line 1 and column 1 was not closed" ) );
         }
     }
 
@@ -545,7 +574,7 @@ public class MXParserTest
         }
         catch ( XmlPullParserException ex )
         {
-            assertTrue( ex.getMessage().contains( "processing instruction started on line 1 and column 13 was not closed" ) );
+            assertTrue( ex.getMessage().contains( "processing instruction started on line 1 and column 12 was not closed" ) );
         }
     }
 
@@ -661,4 +690,8 @@ public class MXParserTest
         }
     }
 
+    private static void assertPosition(int row, int col, MXParser parser) {
+        assertEquals("Current line", row, parser.getLineNumber());
+        assertEquals("Current column", col, parser.getColumnNumber());
+    }
 }

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXParserTest.java
@@ -356,6 +356,37 @@ public class MXParserTest
     }
 
     @Test
+    public void testMalformedProcessingInstructionsContainingXmlNoClosingQuestionMark()
+        throws Exception
+    {
+        StringBuffer sb = new StringBuffer();
+        sb.append( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );
+        sb.append( "<project />\n" );
+        sb.append( "<?pi\n" );
+        sb.append( "   <tag>\n" );
+        sb.append( "   </tag>>\n" );
+
+        MXParser parser = new MXParser();
+        parser.setInput( new StringReader( sb.toString() ) );
+
+        try
+        {
+            assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+            assertEquals( XmlPullParser.IGNORABLE_WHITESPACE, parser.nextToken() );
+            assertEquals( XmlPullParser.START_TAG, parser.nextToken() );
+            assertEquals( XmlPullParser.END_TAG, parser.nextToken() );
+            assertEquals( XmlPullParser.IGNORABLE_WHITESPACE, parser.nextToken() );
+            assertEquals( XmlPullParser.PROCESSING_INSTRUCTION, parser.nextToken() );
+
+            fail( "Should fail since it has invalid PI" );
+        }
+        catch ( XmlPullParserException ex )
+        {
+            assertTrue( ex.getMessage().contains( "processing instruction started on line 3 and column 1 was not closed" ) );
+        }
+    }
+
+    @Test
     public void testSubsequentProcessingInstructionShort()
         throws Exception
     {


### PR DESCRIPTION
The parser still enters an endless loop with an invalid PI, now when it contains XML. Already reported in #118. PR requires #121 applied first.