### PR TITLE
Fix #116 : Java 16 support for ReflectionUtils

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/ReflectionUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/ReflectionUtils.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
  * @author <a href="mailto:michal@codehaus.org">Michal Maczka</a>
  * @author <a href="mailto:jesse@codehaus.org">Jesse McConnell</a>
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
- *
  */
 public final class ReflectionUtils
 {
@@ -126,7 +125,7 @@ public final class ReflectionUtils
 
     /**
      * @param method the method
-     * @return  the class of the argument to the setter. Will throw an RuntimeException if the method isn't a setter.
+     * @return the class of the argument to the setter. Will throw an RuntimeException if the method isn't a setter.
      */
     public static Class<?> getSetterType( Method method )
     {
@@ -163,6 +162,7 @@ public final class ReflectionUtils
 
     /**
      * Generates a map of the fields and values on a given object, also pulls from superclasses
+     * 
      * @param variable field name
      * @param object the object to generate the list of fields from
      * @return map containing the fields and their values
@@ -217,6 +217,14 @@ public final class ReflectionUtils
     {
 
         Class<?> clazz = object.getClass();
+
+        if ( Float.parseFloat( System.getProperty( "java.specification.version" ) ) >= 11
+            && Class.class.getCanonicalName().equals( clazz.getCanonicalName() ) )
+        {
+            // Updating Class fields accessibility is forbidden on Java 16 (and throws warning from version 11)
+            // No concrete use case to modify accessibility at this level
+            return;
+        }
 
         Field[] fields = clazz.getDeclaredFields();
 


### PR DESCRIPTION
Proposal for #116. It is more a workaround, could break backward compatibility.

If updating fields accessibility becomes really forbidden in Java 16 for "Class", the usage of Reflection should be updated according that.
Functionally, the impact would be minor. Generally the usage of Reflection is on "personal / business" classes, not for concrete use case directly on "Class".