### PR TITLE
Fix MXParser failing to parse properly 'standalone' declaration attribute (#130)

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXParser.java
@@ -3325,9 +3325,9 @@ public class MXParser
 
             // TODO reconcile with setInput encodingName
             inputEncoding = newString( buf, encodingStart, encodingEnd - encodingStart );
-            ch = more();
         }
 
+        ch = more();
         ch = skipS( ch );
         // [32] SDDecl ::= S 'standalone' Eq (("'" ('yes' | 'no') "'") | ('"' ('yes' | 'no') '"'))
         if ( ch == 's' )
@@ -3858,17 +3858,6 @@ public class MXParser
             ch = more();
         }
         return ch;
-    }
-
-    private char requireNextS()
-        throws XmlPullParserException, IOException
-    {
-        final char ch = more();
-        if ( !isS( ch ) )
-        {
-            throw new XmlPullParserException( "white space is required and not " + printable( ch ), this, null );
-        }
-        return skipS( ch );
     }
 
     private char skipS( char ch )

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/IBMXML10Tests_Test_IBMXMLConformanceTestSuite_not_wftests_Test_IBMXMLConformanceTestSuite_Production32_Test.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/IBMXML10Tests_Test_IBMXMLConformanceTestSuite_not_wftests_Test_IBMXMLConformanceTestSuite_Production32_Test.java
@@ -1,0 +1,269 @@
+package org.codehaus.plexus.util.xml.pull;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class that execute a particular set of tests associated to a TESCASES tag from the XML W3C Conformance Tests.
+ * TESCASES PROFILE: <pre>IBM XML Conformance Test Suite - Production 32</pre>
+ * XML test files base folder: <pre>xmlconf/ibm/</pre>
+ *
+ * @author <a href="mailto:belingueres@gmail.com">Gabriel Belingueres</a>
+ */
+public class IBMXML10Tests_Test_IBMXMLConformanceTestSuite_not_wftests_Test_IBMXMLConformanceTestSuite_Production32_Test
+{
+
+    final static File testResourcesDir = new File( "src/test/resources/", "xmlconf/ibm/" );
+
+    MXParser parser;
+
+    @Before
+    public void setUp()
+    {
+        parser = new MXParser();
+    }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n01.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n01.xml</pre>
+   * Comment: <pre>Tests SDDecl with a required field missing. The leading white space     is missing with the SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n01xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n01.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with a required field missing. The leading white space     is missing with the SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n02.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n02.xml</pre>
+   * Comment: <pre>Tests SDDecl with a required field missing. The "=" sign is missing     in the SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n02xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n02.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with a required field missing. The \"=\" sign is missing     in the SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n03.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n03.xml</pre>
+   * Comment: <pre>Tests SDDecl with wrong key word. The word "Standalone" occurs in      the SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n03xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n03.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with wrong key word. The word \"Standalone\" occurs in      the SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n04.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n04.xml</pre>
+   * Comment: <pre>Tests SDDecl with wrong key word. The word "Yes" occurs in the     SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n04xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n04.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with wrong key word. The word \"Yes\" occurs in the     SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n05.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n05.xml</pre>
+   * Comment: <pre>Tests SDDecl with wrong key word. The word "YES" occurs in the     SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n05xml()
+      throws IOException
+  {
+
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n05.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with wrong key word. The word \"YES\" occurs in the     SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n06.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n06.xml</pre>
+   * Comment: <pre>Tests SDDecl with wrong key word. The word "No" occurs in the     SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n06xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n06.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with wrong key word. The word \"No\" occurs in the     SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n07.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n07.xml</pre>
+   * Comment: <pre>Tests SDDecl with wrong key word. The word "NO" occurs in the     SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n07xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n07.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with wrong key word. The word \"NO\" occurs in the     SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n08.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n08.xml</pre>
+   * Comment: <pre>Tests SDDecl with wrong field ordering. The "=" sign occurs      after the key word "yes" in the SDDecl in the XMLDecl.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n08xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n08.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "Tests SDDecl with wrong field ordering. The \"=\" sign occurs      after the key word \"yes\" in the SDDecl in the XMLDecl." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+  /**
+   * Test ID: <pre>ibm-not-wf-P32-ibm32n09.xml</pre>
+   * Test URI: <pre>not-wf/P32/ibm32n09.xml</pre>
+   * Comment: <pre>This is test violates WFC: Entity Declared in P68.     The standalone document declaration has the value yes, BUT there is an      external markup declaration of an entity (other than amp, lt, gt, apos,     quot), and references to this entity appear in the document.</pre>
+   * Sections: <pre>2.9</pre>
+   * Version:
+   *
+   * @throws IOException if there is an I/O error
+   */
+  @Test
+  public void testibm_not_wf_P32_ibm32n09xml()
+      throws IOException
+  {
+      try ( Reader reader = new FileReader( new File( testResourcesDir, "not-wf/P32/ibm32n09.xml" ) ) )
+      {
+          parser.setInput( reader );
+          while ( parser.nextToken() != XmlPullParser.END_DOCUMENT )
+              ;
+          fail( "This is test violates WFC: Entity Declared in P68.     The standalone document declaration has the value yes, BUT there is an      external markup declaration of an entity (other than amp, lt, gt, apos,     quot), and references to this entity appear in the document." );
+      }
+      catch ( XmlPullParserException e )
+      {
+          assertTrue( e.getMessage().contains( "expected ?> as last part of <?xml not t" ) );
+      }
+  }
+
+}

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n01.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n01.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"standalone="yes" ?>
+<!DOCTYPE animal [
+   <!ELEMENT animal EMPTY>
+]>
+<!-- Missing a S in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n02.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n02.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone"yes" ?>
+<!DOCTYPE animal [
+   <!ELEMENT animal EMPTY>
+]>
+<!-- Missing Eq in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n03.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n03.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" Standalone="yes" ?>
+<!DOCTYPE animal [
+   <!ELEMENT animal EMPTY>
+]>
+<!-- Wrong keyword in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n04.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n04.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="Yes" ?>
+<!DOCTYPE animal [
+   <!ELEMENT animal EMPTY>
+]>
+<!-- Wrong keyword in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n05.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n05.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="YES" ?>
+<!DOCTYPE animal [
+   <!ELEMENT animal EMPTY>
+]>
+<!-- Wrong keyword in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n06.dtd
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n06.dtd
@@ -1,0 +1,1 @@
+<!ELEMENT animal EMPTY>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n06.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n06.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="No" ?>
+<!DOCTYPE animal SYSTEM "ibm32n06.dtd">
+<!-- Wrong keyword in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n07.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n07.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="NO" ?>
+<!DOCTYPE animal SYSTEM "ibm32n06.dtd">
+<!-- Wrong keyword in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n08.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n08.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone"Yes"= ?>
+<!DOCTYPE animal [
+   <!ELEMENT animal EMPTY>
+]>
+<!-- Wrong ordering in SDDecl -->
+<animal/>

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n09.dtd
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n09.dtd
@@ -1,0 +1,1 @@
+<!ENTITY animal_content "This is a yellow tiger">

--- a/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n09.xml
+++ b/src/test/resources/xmlconf/ibm/not-wf/P32/ibm32n09.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes" ?>
+<!DOCTYPE animal SYSTEM "ibm32n09.dtd" [
+   <!ELEMENT animal (#PCDATA)>
+]>
+<!-- This is test violates WFC: Entity Declared in P68
+ The standalone document declaration has the value "yes", there is an 
+ external markup declaration of an entity (other than amp, lt, gt, apos, quot), and references to this entity appear in the document. 
+-->
+<animal>&animal_content;</animal>


### PR DESCRIPTION
- fixed the bug.
- removed unused requireNextS() method.