### PR TITLE
Using JDK 16 GA instead of JDK 16 EA

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 14, 15]
+        java: [8, 11, 14, 15, 16]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Since JDK 16 is generally available it makes no sense to use an early access build anybody.