### PR TITLE
Enforcing JDK 11 on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,5 +223,30 @@ limitations under the License.
         </pluginManagement>
       </build>
     </profile>
+    <profile>
+      <id>plexus-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>11</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Enforcing the use of JDK 11 on release guarantees that the published Multi-Release JAR contains ALL code versions: JDK 8 (default fallback), JDK 9 (enhanced NIO) and JDK 10 (even further enhanced NIO). Without this enforcement, there would be a risk of not having some of these versions packed into the MRJAR due to the way the POM checks for the existence of supported JDK levels using JDK-enabled profiles.

This PR was requested by @olamy in https://github.com/codehaus-plexus/plexus-utils/pull/120#issuecomment-813327648, and is effective only in the `plexus-release` profile as requested by @rfscholte  in https://github.com/codehaus-plexus/plexus-utils/pull/148#discussion_r607186506. While it technically would be _enough_ to just enforce JDK 10, and while it would be _more future-proof_ to even enforce JDK 16, it follows @olamy 's preference mentioned in https://github.com/codehaus-plexus/plexus-utils/pull/120#issuecomment-813203371, hence enforce JDK 11 instead.