### PR TITLE
Fixed #191

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
@@ -251,23 +251,38 @@ public final class SelectorUtils
 
     public static boolean matchPath( String pattern, String str, String separator, boolean isCaseSensitive )
     {
-        if ( isRegexPrefixedPattern( pattern ) )
+        /* 2022-03-30: Fixed: Caller parameter in a public method should be handled immutable. */
+        String localPattern = pattern;
+        if ( isRegexPrefixedPattern( localPattern ) )
         {
-            pattern =
-                pattern.substring( REGEX_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length() );
+            localPattern =
+                localPattern.substring( REGEX_HANDLER_PREFIX.length(), localPattern.length() - PATTERN_HANDLER_SUFFIX.length() );
 
-            return str.matches( pattern );
+            return str.matches( localPattern );
         }
         else
         {
-            if ( isAntPrefixedPattern( pattern ) )
+            if ( isAntPrefixedPattern( localPattern ) )
             {
-                pattern = pattern.substring( ANT_HANDLER_PREFIX.length(),
-                                             pattern.length() - PATTERN_HANDLER_SUFFIX.length() );
+                localPattern = localPattern.substring( ANT_HANDLER_PREFIX.length(),
+                                             localPattern.length() - PATTERN_HANDLER_SUFFIX.length() );
             }
-
-            return matchAntPathPattern( pattern, str, separator, isCaseSensitive );
+            final String osRelatedPath = toOSRelatedPath( str, separator );
+            final String osRelatedPattern = toOSRelatedPath( localPattern, separator );
+            return matchAntPathPattern( osRelatedPattern, osRelatedPath, separator, isCaseSensitive );
         }
+    }
+
+    private static String toOSRelatedPath( String pattern, String separator )
+    {
+        if ( "/".equals( separator ) )
+        {
+            return pattern.replace( "\\", separator );
+        }
+        if ( "\\".equals( separator ) ) {
+            return pattern.replace( "/", separator );
+        }
+        return pattern;
     }
 
     static boolean isRegexPrefixedPattern( String pattern )

--- a/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
@@ -251,22 +251,18 @@ public final class SelectorUtils
 
     public static boolean matchPath( String pattern, String str, String separator, boolean isCaseSensitive )
     {
-        /* 2022-03-30: Fixed: Caller parameter in a public method should be handled immutable. */
-        String localPattern = pattern;
-        if ( isRegexPrefixedPattern( localPattern ) )
+        if ( isRegexPrefixedPattern( pattern ) )
         {
-            localPattern =
-                localPattern.substring( REGEX_HANDLER_PREFIX.length(), localPattern.length() - PATTERN_HANDLER_SUFFIX.length() );
+            String localPattern =
+                pattern.substring( REGEX_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length() );
 
             return str.matches( localPattern );
         }
         else
         {
-            if ( isAntPrefixedPattern( localPattern ) )
-            {
-                localPattern = localPattern.substring( ANT_HANDLER_PREFIX.length(),
-                                             localPattern.length() - PATTERN_HANDLER_SUFFIX.length() );
-            }
+            String localPattern = isAntPrefixedPattern( pattern )
+                ? pattern.substring( ANT_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length() )
+                : pattern;
             final String osRelatedPath = toOSRelatedPath( str, separator );
             final String osRelatedPattern = toOSRelatedPath( localPattern, separator );
             return matchAntPathPattern( osRelatedPattern, osRelatedPath, separator, isCaseSensitive );

--- a/src/test/java/org/codehaus/plexus/util/SelectorUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/SelectorUtilsTest.java
@@ -92,4 +92,55 @@ public class SelectorUtilsTest
         // Pattern and target don't start with file separator
         assertTrue( SelectorUtils.matchPath( "*" + separator + "a.txt", "b" + separator + "a.txt", separator, false ) );
     }
+
+    @Test
+    public void testPatternMatchSingleWildCardLinux()
+    {
+        assertFalse(SelectorUtils.matchPath(
+            "/com/test/*",
+            "/com/test/test/hallo"));
+    }
+
+
+    @Test
+    public void testPatternMatchDoubleWildCardCaseInLinux()
+    {
+        assertTrue(SelectorUtils.matchPath(
+            "/com/test/**",
+            "/com/test/test/hallo"));
+    }
+
+
+    @Test
+    public void testPatternMatchDoubleWildCardLinux()
+    {
+        assertTrue(SelectorUtils.matchPath(
+            "/com/test/**",
+            "/com/test/test/hallo"));
+    }
+
+
+    @Test
+    public void testPatternMatchSingleWildCardWindows()
+    {
+        assertFalse(SelectorUtils.matchPath(
+            "D:\\com\\test\\*",
+            "D:\\com\\test\\test\\hallo"));
+
+        assertFalse(SelectorUtils.matchPath(
+            "D:/com/test/*",
+            "D:/com/test/test/hallo"));
+    }
+
+    @Test
+    public void testPatternMatchDoubleWildCardWindows()
+    {
+        assertTrue(SelectorUtils.matchPath(
+            "D:\\com\\test\\**",
+            "D:\\com\\test\\test\\hallo"));
+
+        assertTrue(SelectorUtils.matchPath(
+            "D:\\com\\test\\**",
+            "D:/com/test/test/hallo"));
+    }
 }


### PR DESCRIPTION
HI,

Please have a look at this fix regarding #191.

The matchPath method has also modified the passing parameters. This must be prevented in any case, because the method is called from foreign code. I recommend setting the IDE to mark all variables as final. Should also be considered in the code style.

BR
Fishermans