### PR TITLE
Use Path in the Scanner API

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/DirectoryScanner.java
+++ b/src/main/java/org/codehaus/plexus/util/DirectoryScanner.java
@@ -56,6 +56,7 @@ package org.codehaus.plexus.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -236,9 +237,9 @@ public class DirectoryScanner
      * @return the base directory to be scanned
      */
     @Override
-    public File getBasedir()
+    public Path getBasedir()
     {
-        return basedir;
+        return basedir.toPath();
     }
 
     /**

--- a/src/main/java/org/codehaus/plexus/util/Scanner.java
+++ b/src/main/java/org/codehaus/plexus/util/Scanner.java
@@ -16,7 +16,7 @@ package org.codehaus.plexus.util;
  * limitations under the License.
  */
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Comparator;
 
 /**
@@ -83,7 +83,7 @@ public interface Scanner
      *
      * @return the base directory to be scanned
      */
-    File getBasedir();
+    Path getBasedir();
 
     /**
      * Use a filename comparator in each directory when scanning.


### PR DESCRIPTION
This would be a minimal change to move the API of `Scanner` to the `Path` API

This could be some kind of minimal change that could be merged as base for larger changes like:
- https://github.com/codehaus-plexus/plexus-utils/pull/225