### PR TITLE
Using Java 11's readString and writeString on modern JREs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,36 @@ limitations under the License.
       </build>
     </profile>
     <profile>
+        <id>jdk11+</id>
+        <activation>
+          <jdk>[11,)</jdk>
+        </activation>
+        <build>
+          <pluginManagement>
+            <plugins>
+              <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>compile-java-11</id>
+                    <goals>
+                      <goal>compile</goal>
+                    </goals>
+                    <configuration>
+                      <release>11</release>
+                      <compileSourceRoots>
+                        <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                    </compileSourceRoots>
+                    <multiReleaseOutput>true</multiReleaseOutput>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </pluginManagement>
+        </build>
+      </profile>
+    <profile>
       <id>plexus-release</id>
       <build>
         <plugins>

--- a/src/main/java/org/codehaus/plexus/util/BaseFileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/BaseFileUtils.java
@@ -1,0 +1,23 @@
+package org.codehaus.plexus.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Implementation specific to Java SE 8 version.
+ */
+abstract class BaseFileUtils
+{
+    static String fileRead( Path path, String encoding ) throws IOException
+    {
+        byte[] bytes = Files.readAllBytes( path );
+        return encoding != null ? new String( bytes, encoding ) : new String( bytes );
+    }
+
+    static void fileWrite( Path path, String encoding, String data ) throws IOException
+    {
+        byte[] bytes = encoding != null ? data.getBytes( encoding ) : data.getBytes();
+        Files.write( path, bytes );
+    }
+}

--- a/src/main/java/org/codehaus/plexus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/FileUtils.java
@@ -114,7 +114,7 @@ import java.util.Random;
  * @author <a href="mailto:jefft@codehaus.org">Jeff Turner</a>
  *
  */
-public class FileUtils
+public class FileUtils extends BaseFileUtils
 {
     /**
      * The number of bytes in a kilobyte.
@@ -330,7 +330,7 @@ public class FileUtils
     public static String fileRead( String file, String encoding )
         throws IOException
     {
-        return fileRead( new File( file ), encoding );
+        return fileRead( Paths.get( file ), encoding );
     }
 
     /**
@@ -356,13 +356,6 @@ public class FileUtils
         throws IOException
     {
         return fileRead( file.toPath(), encoding );
-    }
-
-    private static String fileRead( Path path, String encoding )
-        throws IOException
-    {
-        byte[] bytes = Files.readAllBytes( path );
-        return encoding != null ? new String( bytes, encoding ) : new String( bytes );
     }
 
     /**
@@ -433,7 +426,7 @@ public class FileUtils
     public static void fileWrite( String fileName, String encoding, String data )
         throws IOException
     {
-        File file = ( fileName == null ) ? null : new File( fileName );
+        Path file = ( fileName == null ) ? null : Paths.get( fileName );
         fileWrite( file, encoding, data );
     }
 
@@ -465,13 +458,6 @@ public class FileUtils
         throws IOException
     {
         fileWrite( file.toPath(), encoding, data );
-    }
-
-    private static void fileWrite( Path path, String encoding, String data )
-        throws IOException
-    {
-        byte[] bytes = encoding != null ? data.getBytes( encoding ) : data.getBytes();
-        Files.write( path, bytes );
     }
 
     /**

--- a/src/main/java11/org/codehaus/plexus/util/BaseFileUtils.java
+++ b/src/main/java11/org/codehaus/plexus/util/BaseFileUtils.java
@@ -1,0 +1,29 @@
+package org.codehaus.plexus.util;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Implementation specific to Java SE 11 version.
+ */
+abstract class BaseFileUtils
+{
+    static String fileRead( Path path, String encoding ) throws IOException
+    {
+        return encoding != null ? Files.readString( path, Charset.forName( encoding ) ) : Files.readString( path );
+    }
+
+    static void fileWrite( Path path, String encoding, String data ) throws IOException
+    {
+        if ( encoding != null )
+        {
+            Files.writeString( path, data, Charset.forName( encoding ) );
+        }
+        else
+        {
+            Files.writeString( path, data );
+        }
+    }
+}

--- a/src/test/java/org/codehaus/plexus/util/FileUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/FileUtilsTest.java
@@ -33,6 +33,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.junit.Before;
@@ -191,7 +192,7 @@ public final class FileUtilsTest
 
         for ( int i = 0; i < urls.length; i++ )
         {
-            assertEquals( files[i].toURL(), urls[i] );
+            assertEquals( files[i].toURI().toURL(), urls[i] );
         }
     }
 
@@ -885,14 +886,12 @@ public final class FileUtilsTest
         final URL url = this.getClass().getResource( path );
         assertNotNull( path + " was not found.", url );
 
-        String filename = url.getFile();
-        // The following line applies a fix for spaces in a path
-        filename = replaceAll( filename, "%20", " " );
+        final String filename = Paths.get(url.toURI()).toString();
         final String filename2 = "test2.txt";
 
         assertTrue( "test.txt extension == \"txt\"", FileUtils.getExtension( filename ).equals( "txt" ) );
 
-        assertTrue( "Test file does not exist: " + filename, FileUtils.fileExists( filename ) );
+        assertTrue( "Test file does exist: " + filename, FileUtils.fileExists( filename ) );
 
         assertTrue( "Second test file does not exist", !FileUtils.fileExists( filename2 ) );
 


### PR DESCRIPTION
As the latest Java release was 19 (and 20 will be here in few weeks), it makes sense to allow users of those JREs to take advantage of their superior APIs. In this PR, I am proposing to use the single-line `Files.readString` and `Files.writeString` methods on all modern JREs (11+) instead of dealing with interim custom byte-to-String operations needed since JRE 7 through 10. For the sake of this, I have adopted the multi-release pattern to `FileUtils` in the same way we already applied it years ago to `BaseIOUtils`. As such, JRE 11 through 21 (and further) will be as fast as possible when reading / writing text files.