### PR TITLE
fileAppend makes use of optimized fileWrite implementations for JRE 8 and JRE 11

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/BaseFileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/BaseFileUtils.java
@@ -2,7 +2,9 @@ package org.codehaus.plexus.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Implementation specific to Java SE 8 version.
@@ -15,9 +17,9 @@ abstract class BaseFileUtils
         return encoding != null ? new String( bytes, encoding ) : new String( bytes );
     }
 
-    static void fileWrite( Path path, String encoding, String data ) throws IOException
+    static void fileWrite( Path path, String encoding, String data, OpenOption... openOptions ) throws IOException
     {
         byte[] bytes = encoding != null ? data.getBytes( encoding ) : data.getBytes();
-        Files.write( path, bytes );
+        Files.write( path, bytes, openOptions );
     }
 }

--- a/src/main/java/org/codehaus/plexus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/FileUtils.java
@@ -387,18 +387,12 @@ public class FileUtils extends BaseFileUtils
     public static void fileAppend( String fileName, String encoding, String data )
         throws IOException
     {
-        try ( OutputStream out = Files.newOutputStream( Paths.get(fileName),
-                StandardOpenOption.APPEND, StandardOpenOption.CREATE ) )
-        {
-            if ( encoding != null )
-            {
-                out.write( data.getBytes( encoding ) );
-            }
-            else
-            {
-                out.write( data.getBytes() );
-            }
-        }
+        fileAppend( Paths.get( fileName), encoding, data );
+    }
+
+    private static void fileAppend( Path path, String encoding, String data ) throws IOException
+    {
+        fileWrite( path, encoding, data, StandardOpenOption.APPEND, StandardOpenOption.CREATE );
     }
 
     /**

--- a/src/main/java11/org/codehaus/plexus/util/BaseFileUtils.java
+++ b/src/main/java11/org/codehaus/plexus/util/BaseFileUtils.java
@@ -3,7 +3,9 @@ package org.codehaus.plexus.util;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Implementation specific to Java SE 11 version.
@@ -15,15 +17,15 @@ abstract class BaseFileUtils
         return encoding != null ? Files.readString( path, Charset.forName( encoding ) ) : Files.readString( path );
     }
 
-    static void fileWrite( Path path, String encoding, String data ) throws IOException
+    static void fileWrite( Path path, String encoding, String data, OpenOption... openOptions ) throws IOException
     {
         if ( encoding != null )
         {
-            Files.writeString( path, data, Charset.forName( encoding ) );
+            Files.writeString( path, data, Charset.forName( encoding ), openOptions );
         }
         else
         {
-            Files.writeString( path, data );
+            Files.writeString( path, data, openOptions );
         }
     }
 }


### PR DESCRIPTION
Recently we optimized the fileWrite method for JRE 8 and JRE 11. This PR rewrites the fileAppend method so it makes use of these optimized implementations, while reducing the code size at the same time.