### PR TITLE
V4 changes to make external usage easier

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/MatchPattern.java
+++ b/src/main/java/org/codehaus/plexus/util/MatchPattern.java
@@ -59,7 +59,7 @@ public class MatchPattern {
     }
 
     /**
-     * Gets the source pattern for this matchpattern.
+     * Gets the source pattern for this match pattern.
      * @return the source string without Ant or Regex pattern markers.
      */
     public String getSource() {

--- a/src/main/java/org/codehaus/plexus/util/MatchPattern.java
+++ b/src/main/java/org/codehaus/plexus/util/MatchPattern.java
@@ -58,6 +58,14 @@ public class MatchPattern {
         }
     }
 
+    /**
+     * Gets the source pattern for this matchpattern.
+     * @return the source string without Ant or Regex pattern markers.
+     */
+    public String getSource() {
+        return source;
+    }
+
     public boolean matchPath(String str, boolean isCaseSensitive) {
         if (regexPattern != null) {
             return str.matches(regexPattern);
@@ -99,7 +107,7 @@ public class MatchPattern {
         return source.startsWith(string);
     }
 
-    static String[] tokenizePathToString(String path, String separator) {
+    public static String[] tokenizePathToString(String path, String separator) {
         List<String> ret = new ArrayList<String>();
         StringTokenizer st = new StringTokenizer(path, separator);
         while (st.hasMoreTokens()) {

--- a/src/main/java/org/codehaus/plexus/util/MatchPattern.java
+++ b/src/main/java/org/codehaus/plexus/util/MatchPattern.java
@@ -63,7 +63,7 @@ public class MatchPattern {
      * @return the source string without Ant or Regex pattern markers.
      */
     public String getSource() {
-        return source;
+        return regexPattern == null ? source : regexPattern;
     }
 
     public boolean matchPath(String str, boolean isCaseSensitive) {

--- a/src/main/java/org/codehaus/plexus/util/MatchPatterns.java
+++ b/src/main/java/org/codehaus/plexus/util/MatchPatterns.java
@@ -17,6 +17,18 @@ public class MatchPatterns {
     }
 
     /**
+     * Gets a list of enclosed MatchPattern sources.
+     * @return A list of enclosed MatchPattern sources.
+     */
+    public List<String> getSources() {
+        List<String> sources = new ArrayList<>();
+        for (MatchPattern pattern : patterns) {
+            sources.add(pattern.getSource());
+        }
+        return sources;
+    }
+
+    /**
      * <p>Checks these MatchPatterns against a specified string.</p>
      *
      * <p>Uses far less string tokenization than any of the alternatives.</p>

--- a/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
@@ -243,6 +243,17 @@ public final class SelectorUtils {
         }
     }
 
+    public static String extractPattern(final String pattern, final String separator) {
+        if (isRegexPrefixedPattern(pattern)) {
+            return pattern.substring(REGEX_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length());
+        } else {
+            String localPattern = isAntPrefixedPattern(pattern)
+                    ? pattern.substring(ANT_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length())
+                    : pattern;
+            return toOSRelatedPath(localPattern, separator);
+        }
+    }
+
     private static String toOSRelatedPath(String pattern, String separator) {
         if ("/".equals(separator)) {
             return pattern.replace("\\", separator);
@@ -253,7 +264,7 @@ public final class SelectorUtils {
         return pattern;
     }
 
-    static boolean isRegexPrefixedPattern(String pattern) {
+    public static boolean isRegexPrefixedPattern(String pattern) {
         return pattern.length() > (REGEX_HANDLER_PREFIX.length() + PATTERN_HANDLER_SUFFIX.length() + 1)
                 && pattern.startsWith(REGEX_HANDLER_PREFIX)
                 && pattern.endsWith(PATTERN_HANDLER_SUFFIX);

--- a/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
@@ -139,7 +139,7 @@ public final class SelectorUtils {
         }
     }
 
-    static boolean isAntPrefixedPattern(String pattern) {
+    public static boolean isAntPrefixedPattern(String pattern) {
         return pattern.length() > (ANT_HANDLER_PREFIX.length() + PATTERN_HANDLER_SUFFIX.length() + 1)
                 && pattern.startsWith(ANT_HANDLER_PREFIX)
                 && pattern.endsWith(PATTERN_HANDLER_SUFFIX);
@@ -240,17 +240,6 @@ public final class SelectorUtils {
             final String osRelatedPath = toOSRelatedPath(str, separator);
             final String osRelatedPattern = toOSRelatedPath(localPattern, separator);
             return matchAntPathPattern(osRelatedPattern, osRelatedPath, separator, isCaseSensitive);
-        }
-    }
-
-    public static String extractPattern(final String pattern, final String separator) {
-        if (isRegexPrefixedPattern(pattern)) {
-            return pattern.substring(REGEX_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length());
-        } else {
-            String localPattern = isAntPrefixedPattern(pattern)
-                    ? pattern.substring(ANT_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length())
-                    : pattern;
-            return toOSRelatedPath(localPattern, separator);
         }
     }
 
@@ -718,5 +707,23 @@ public final class SelectorUtils {
             }
         }
         return result.toString();
+    }
+
+    /**
+     * Extract the pattern without the Regex or Ant prefix.  In the case of Ant style matches ensure
+     * that the path uses specified separator.
+     * @param pattern the pattern to extract from.
+     * @param separator the system file name separator in the pattern.
+     * @return The pattern without the Regex or Ant prefix.
+     */
+    public static String extractPattern(final String pattern, final String separator) {
+        if (isRegexPrefixedPattern(pattern)) {
+            return pattern.substring(REGEX_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length());
+        } else {
+            String localPattern = isAntPrefixedPattern(pattern)
+                    ? pattern.substring(ANT_HANDLER_PREFIX.length(), pattern.length() - PATTERN_HANDLER_SUFFIX.length())
+                    : pattern;
+            return toOSRelatedPath(localPattern, separator);
+        }
     }
 }

--- a/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/SelectorUtils.java
@@ -140,7 +140,7 @@ public final class SelectorUtils {
     }
 
     public static boolean isAntPrefixedPattern(String pattern) {
-        return pattern.length() > (ANT_HANDLER_PREFIX.length() + PATTERN_HANDLER_SUFFIX.length() + 1)
+        return pattern.length() > (ANT_HANDLER_PREFIX.length() + PATTERN_HANDLER_SUFFIX.length())
                 && pattern.startsWith(ANT_HANDLER_PREFIX)
                 && pattern.endsWith(PATTERN_HANDLER_SUFFIX);
     }
@@ -254,7 +254,7 @@ public final class SelectorUtils {
     }
 
     public static boolean isRegexPrefixedPattern(String pattern) {
-        return pattern.length() > (REGEX_HANDLER_PREFIX.length() + PATTERN_HANDLER_SUFFIX.length() + 1)
+        return pattern.length() > (REGEX_HANDLER_PREFIX.length() + PATTERN_HANDLER_SUFFIX.length())
                 && pattern.startsWith(REGEX_HANDLER_PREFIX)
                 && pattern.endsWith(PATTERN_HANDLER_SUFFIX);
     }

--- a/src/test/java/org/codehaus/plexus/util/MatchPatternTest.java
+++ b/src/test/java/org/codehaus/plexus/util/MatchPatternTest.java
@@ -18,6 +18,8 @@ package org.codehaus.plexus.util;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +31,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 3.4.0
  */
 public class MatchPatternTest {
+
+    /**
+     * <p>testGetSource</p>
+     */
+    @Test
+    public void testGetSource() {
+        MatchPattern mp = MatchPattern.fromString("ABC*");
+        assertEquals("ABC*", mp.getSource());
+        mp = MatchPattern.fromString("%ant[some/ABC*]");
+        assertEquals("some/ABC*", mp.getSource());
+        mp = MatchPattern.fromString("%regex[[ABC].*]");
+        assertEquals("[ABC].*", mp.getSource());
+    }
+
     /**
      * <p>testMatchPath.</p>
      *
@@ -57,5 +73,21 @@ public class MatchPatternTest {
 
         assertFalse(mp.matchPatternStart("XXXX", true));
         assertFalse(mp.matchPatternStart("XXXX", false));
+    }
+
+    /**
+     * <p>testTokenizePathToString.</p>
+     */
+    @Test
+    public void testTokenizePathToString() {
+        String[] expected = {"hello", "world"};
+        String[] actual = MatchPattern.tokenizePathToString("hello/world", "/");
+        assertArrayEquals(expected, actual);
+
+        actual = MatchPattern.tokenizePathToString("/hello/world", "/");
+        assertArrayEquals(expected, actual);
+
+        actual = MatchPattern.tokenizePathToString("/hello/world/", "/");
+        assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/org/codehaus/plexus/util/MatchPatternsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/MatchPatternsTest.java
@@ -16,8 +16,12 @@ package org.codehaus.plexus.util;
  * limitations under the License.
  */
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +33,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 3.4.0
  */
 public class MatchPatternsTest {
+    /**
+     * <p>testGetSource</p>
+     */
+    @Test
+    public void testGetSources() {
+        List<String> expected = Arrays.asList("ABC**", "some/ABC*", "[ABC].*");
+        MatchPatterns from = MatchPatterns.from("ABC**", "%ant[some/ABC*]", "%regex[[ABC].*]");
+        List<String> actual = from.getSources();
+        assertEquals(expected, actual);
+    }
+
     /**
      * <p>testMatches.</p>
      *

--- a/src/test/java/org/codehaus/plexus/util/SelectorUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/SelectorUtilsTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,6 +31,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 3.4.0
  */
 public class SelectorUtilsTest {
+    /**
+     * <p>testExtractPattern.</p>
+     */
+    @Test
+    public void testExtractPattern() {
+        assertEquals("[A-Z].*", SelectorUtils.extractPattern("%regex[[A-Z].*]", "/"));
+        assertEquals("ABC*", SelectorUtils.extractPattern("%ant[ABC*]", "/"));
+        assertEquals("some/ABC*", SelectorUtils.extractPattern("%ant[some/ABC*]", "/"));
+        assertEquals("some\\ABC*", SelectorUtils.extractPattern("%ant[some\\ABC*]", "\\"));
+        assertEquals("some/ABC*", SelectorUtils.extractPattern("%ant[some\\ABC*]", "/"));
+        assertEquals("some\\ABC*", SelectorUtils.extractPattern("%ant[some/ABC*]", "\\"));
+    }
+
+    /**
+     * <p>testIsAntPrefixedPattern.</p>
+     */
+    @Test
+    public void testIsAntPrefixedPattern() {
+        assertFalse(SelectorUtils.isAntPrefixedPattern("%ant[A]")); // single char not allowed
+        assertTrue(SelectorUtils.isAntPrefixedPattern("%ant[AB]"));
+        assertFalse(SelectorUtils.isAntPrefixedPattern("%ant[]"));
+        assertFalse(SelectorUtils.isAntPrefixedPattern("*"));
+    }
+
+    /**
+     * <p>testIsRegexPrefixedPattern.</p>
+     */
+    @Test
+    public void testIsRegexPrefixedPattern() {
+        assertFalse(SelectorUtils.isRegexPrefixedPattern("%regex[A]")); // single char not allowed
+        assertTrue(SelectorUtils.isRegexPrefixedPattern("%regex[.*]"));
+        assertFalse(SelectorUtils.isRegexPrefixedPattern("%regex[]"));
+        assertFalse(SelectorUtils.isRegexPrefixedPattern("*"));
+    }
+
     /**
      * <p>testMatchPath_DefaultFileSeparator.</p>
      */

--- a/src/test/java/org/codehaus/plexus/util/SelectorUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/SelectorUtilsTest.java
@@ -49,7 +49,7 @@ public class SelectorUtilsTest {
      */
     @Test
     public void testIsAntPrefixedPattern() {
-        assertFalse(SelectorUtils.isAntPrefixedPattern("%ant[A]")); // single char not allowed
+        assertTrue(SelectorUtils.isAntPrefixedPattern("%ant[A]")); // single char not allowed
         assertTrue(SelectorUtils.isAntPrefixedPattern("%ant[AB]"));
         assertFalse(SelectorUtils.isAntPrefixedPattern("%ant[]"));
         assertFalse(SelectorUtils.isAntPrefixedPattern("*"));
@@ -60,7 +60,7 @@ public class SelectorUtilsTest {
      */
     @Test
     public void testIsRegexPrefixedPattern() {
-        assertFalse(SelectorUtils.isRegexPrefixedPattern("%regex[A]")); // single char not allowed
+        assertTrue(SelectorUtils.isRegexPrefixedPattern("%regex[A]")); // single char not allowed
         assertTrue(SelectorUtils.isRegexPrefixedPattern("%regex[.*]"));
         assertFalse(SelectorUtils.isRegexPrefixedPattern("%regex[]"));
         assertFalse(SelectorUtils.isRegexPrefixedPattern("*"));


### PR DESCRIPTION
Fix for #276 and #279 on V4

This change:

- Adds a public String source() method to MatchPattern to return the "source" instance value.
- Makes public MatchPattern method static String[] tokenizePathToString(String path, String separator)
- Adds public List sources() method to MatchPatterns that to return a list of MatchPattern.source() for each enclosed pattern.
- Makes public SelectorUtils static boolean isAntPrefixedPattern() method
- Makes public SelectorUtils static boolean isRegexPrefixedPattern() method
- Adds a SelectorUtils public static String extractPattern(final string pattern, final String separator) method to extract a simplified pattern without the Ant or Regex prefix and with the Ant path modified by a call to toOSRelatedPath to ensure that it is properly formatted.