### PR TITLE
[3.x] Add Automatic-Module-Name manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@ limitations under the License.
           <archive>
             <manifestEntries>
               <Multi-Release>true</Multi-Release>
+              <Automatic-Module-Name>org.codehaus.plexus.util</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
## Summary

- Adds `Automatic-Module-Name: org.codehaus.plexus.util` to the JAR manifest, providing a stable JPMS module name for modular downstream consumers.

Fixes #311
