### PR TITLE
Rewrite README with usage, status and version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,69 @@
-Plexus-Utils
-============
+# Plexus Utils
 
-[![Build Status](https://github.com/codehaus-plexus/plexus-utils/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-utils/actions)
-[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-utils.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-utils)
+[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-utils.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.codehaus.plexus/plexus-utils)
+[![GitHub CI](https://github.com/codehaus-plexus/plexus-utils/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-utils/actions)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/codehaus/plexus/plexus-utils/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/codehaus/plexus/plexus-utils/README.md)
 
-This library is historically used by the Apache Maven project so it's developed and maintained by the same [`bad guys`](http://maven.apache.org/team.html)
+A collection of utility classes for strings, files, command lines and process execution. Historically developed alongside Apache Maven, and maintained by the same people.
 
-The current master is now at https://github.com/codehaus-plexus/plexus-utils
+## Status
 
-For publishing [the site](https://codehaus-plexus.github.io/plexus-utils/) do the following:
+Maintained, conservatively. This artifact is on the classpath of very nearly every Maven build in existence, so public API is kept compatible and new methods are added rarely. Much of it predates equivalents in the JDK and in Commons Lang — for new code, prefer the JDK where one exists.
 
+**Two release lines are current:**
+
+| Line | Latest | Use when |
+|---|---|---|
+| `4.x` | 4.0.x | Default for new work |
+| `3.x` | 3.6.x | You need the XML classes bundled in this artifact rather than split out (see below) |
+
+The `3.x` line lives on the [`plexus-utils-3.x`](https://github.com/codehaus-plexus/plexus-utils/tree/plexus-utils-3.x) branch and still receives releases.
+
+## Upgrading from 3.x to 4.x
+
+**The XML classes moved out.** `org.codehaus.plexus.util.xml` and `org.codehaus.plexus.util.xml.pull` — `Xpp3Dom`, `Xpp3DomBuilder`, `Xpp3DomWriter`, the pull parser — are no longer in `plexus-utils` 4. They live in [`plexus-xml`](https://github.com/codehaus-plexus/plexus-xml).
+
+If you hit `NoClassDefFoundError` on any of those after upgrading, add:
+
+```xml
+<dependency>
+  <groupId>org.codehaus.plexus</groupId>
+  <artifactId>plexus-xml</artifactId>
+  <version>3.0.2</version>
+</dependency>
 ```
-mvn -Preporting verify site site:stage scm-publish:publish-scm
+
+**Pick the `plexus-xml` line carefully:**
+
+- **`plexus-xml` 3.x** is the straight extraction from `plexus-utils` 4 — same classes, same packages. This is what you want for Maven 3 compatibility.
+- **`plexus-xml` 4.x** is rebuilt on Maven 4's `maven-xml-api`, requires **Java 17**, and works only under Maven 4.
+
+`plexus-utils` 4 keeps an *optional* dependency on `plexus-xml` 3 so the few XML-oriented methods on [`ReaderFactory`](https://javadoc.io/doc/org.codehaus.plexus/plexus-utils/latest/org/codehaus/plexus/util/ReaderFactory.html) and [`WriterFactory`](https://javadoc.io/doc/org.codehaus.plexus/plexus-utils/latest/org/codehaus/plexus/util/WriterFactory.html) keep working. Those methods are deprecated — the Javadoc explains what to move to.
+
+## Using it
+
+```xml
+<dependency>
+  <groupId>org.codehaus.plexus</groupId>
+  <artifactId>plexus-utils</artifactId>
+  <version>4.0.3</version>
+</dependency>
 ```
 
-Starting with version 4, XML classes (in `org.codehaus.plexus.util.xml` and `org.codehaus.plexus.util.xml.pull`) have been extracted to a separate [`plexus-xml`](https://github.com/codehaus-plexus/plexus-xml/) library: if you need them, just use this new artifact.
+Check the badge above for the current version.
 
-`plexus-utils` 4 keeps an optional dependency on `plexus-xml` 3 to keep compatibility with the few XML-oriented methods of `ReaderFactory` and `WriterFactory`: these classes are deprecated, you should migrate as explained in javadoc. And keep `plexus-xml` to 3 if you want Maven 3 compatibility, as `plexus-xml` 4 works only in Maven 4.
+## Requirements
+
+Java 8 or later. Both the `4.x` and `3.x` lines currently target Java 8.
+
+## Documentation
+
+- [Project site](https://codehaus-plexus.github.io/plexus-utils/)
+- [Javadoc](https://javadoc.io/doc/org.codehaus.plexus/plexus-utils)
+- [Release notes](https://github.com/codehaus-plexus/plexus-utils/releases)
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/codehaus-plexus/.github/blob/master/CONTRIBUTING.md). In short: `mvn verify` builds, and run `mvn spotless:apply` before pushing or CI will fail on formatting.
+
+Please report security vulnerabilities privately — see [SECURITY.md](https://github.com/codehaus-plexus/.github/blob/master/SECURITY.md), not a public issue.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Maintained, conservatively. This artifact is on the classpath of very nearly eve
 
 **Two release lines are current:**
 
-| Line | Latest | Use when |
-|---|---|---|
-| `4.x` | 4.0.x | Default for new work |
-| `3.x` | 3.6.x | You need the XML classes bundled in this artifact rather than split out (see below) |
+| Line  | Latest |                                      Use when                                       |
+|-------|--------|-------------------------------------------------------------------------------------|
+| `4.x` | 4.0.x  | Default for new work                                                                |
+| `3.x` | 3.6.x  | You need the XML classes bundled in this artifact rather than split out (see below) |
 
 The `3.x` line lives on the [`plexus-utils-3.x`](https://github.com/codehaus-plexus/plexus-utils/tree/plexus-utils-3.x) branch and still receives releases.
 


### PR DESCRIPTION
Part of codehaus-plexus/.github#58. Same skeleton as the approved pilots (codehaus-plexus/plexus-archiver#438, codehaus-plexus/plexus-i18n#37).

This is the repo where the **version guidance** section earns its keep, so it's worth more than a mechanical pass.

### The upgrade story wasn't written down

The old README said the XML classes had moved to `plexus-xml` — but not what to *do* about it. In practice the first thing someone hits upgrading 3 → 4 is `NoClassDefFoundError` on `Xpp3Dom`, and nothing told them the fix. The README now gives the exact dependency to add, and, more importantly, how to choose:

- **`plexus-xml` 3.x** — straight extraction, same classes and packages, works under Maven 3
- **`plexus-xml` 4.x** — rebuilt on Maven 4's `maven-xml-api`, needs **Java 17**, Maven 4 only

Picking the wrong one of those is a bad afternoon, and we documented it nowhere.

It also records that **`3.x` is still an active release line** (3.6.1 shipped from the [`plexus-utils-3.x`](https://github.com/codehaus-plexus/plexus-utils/tree/plexus-utils-3.x) branch), which wasn't stated anywhere. Someone looking only at `master` would reasonably conclude 3.x was dead.

### Status section

Says plainly that this is conservatively maintained, that it's on the classpath of nearly every Maven build, and that **for new code the JDK equivalent is usually the better choice** where one exists. That last point is honest rather than promotional, but it's what I'd tell someone who asked.

### Corrections I made while writing this

Worth flagging, since I nearly shipped both:

1. I first wrote that `3.x` requires **Java 7**. It doesn't — the `plexus-utils-3.x` branch inherits parent POM 25, so `javaVersion` is **8**, same as `4.x`. The two lines don't differ by Java baseline at all, so I dropped that column rather than have the table imply they do.
2. I first wrote `plexus-xml` **3.0.1** in the snippet. Central's latest 3.x is **3.0.2** (3.0.3 is tagged on GitHub but not synced). Checked against `maven-metadata.xml` rather than the Central search index, which is stale — it was reporting plexus-archiver 4.10.0 while 4.12.0 was published.

### Removed

The "The current master is now at https://github.com/codehaus-plexus/plexus-utils" line — shown to a reader already on that page — and the site-publishing recipe, which contradicted this repo's own POM. The POM binds `scm-publish` to `site-deploy` and comments "mono-module doesn't require site:stage", while the README told you to run `site site:stage scm-publish:publish-scm`. That procedure now lives once in [RELEASING.md](https://github.com/codehaus-plexus/.github/blob/master/RELEASING.md) (codehaus-plexus/.github#60).